### PR TITLE
Use WPA2 instead of WPA for access point

### DIFF
--- a/bin/accesspoint
+++ b/bin/accesspoint
@@ -113,6 +113,7 @@ EOF
     # enable ip-forwarding
     sudo sysctl -w net.ipv4.ip_forward=1
     sudo "$IOTEMPOWER_EXTERNAL/create_ap/create_ap" \
+	    -w 2 \
         -c "$CHANNEL" $HIDDEN \
         -g "$IP" \
         $HOSTAPD_EXTRA \

--- a/bin/accesspoint
+++ b/bin/accesspoint
@@ -113,7 +113,7 @@ EOF
     # enable ip-forwarding
     sudo sysctl -w net.ipv4.ip_forward=1
     sudo "$IOTEMPOWER_EXTERNAL/create_ap/create_ap" \
-	    -w 2 \
+        -w 2 \
         -c "$CHANNEL" $HIDDEN \
         -g "$IP" \
         $HOSTAPD_EXTRA \


### PR DESCRIPTION
This is necessary for task 1 - More Temperature from week 6.
ESP32 can't connect to a WPA wifi network using the suggested libraries.