### PR TITLE
Include script to activate the minimal broadcom firmware version on some Raspberry Pis

### DIFF
--- a/bin/iot_install
+++ b/bin/iot_install
@@ -137,8 +137,7 @@ of the wireless chip firmware has to be enabled. Do you want to proceed? (Y/n)"
     read answer
 
     if [ "$answer" == "Y" ] || [ "$answer" == "y" ]; then
-	cd "$IOTEMPOWER_LOCAL"
-        ./bin/unbreak_ap_limit
+        "$IOTEMPOWER_LOCAL"/bin/unbreak_ap_limit
     else
         echo "NB! A maximum of 8 connected clients are supported without the use of minimal broadcom firmware."
     fi

--- a/bin/iot_install
+++ b/bin/iot_install
@@ -131,6 +131,17 @@ else
     cd nodejs
     npm install terminal-kit
 
+    # activate minimal firmware
+    echo "In order to support a larger amount of connected devices, a special minimal version 
+		of the wireless chip firmware has to be enabled. Do you want to proceed? (Y/n)"
+    read answer
+
+    if [ "$answer" == "Y" ] || [ "$answer" == "y" ]; then
+        unbreak_ap_limit
+    else
+        echo "NB! A maximum of 8 connected clients are supported without the use of minimal broadcom firmware."
+    fi
+
     popd  &> /dev/null
 
     bash "$IOTEMPOWER_ROOT/bin/fix_bin"

--- a/bin/iot_install
+++ b/bin/iot_install
@@ -133,11 +133,12 @@ else
 
     # activate minimal firmware
     echo "In order to support a larger amount of connected devices, a special minimal version 
-		of the wireless chip firmware has to be enabled. Do you want to proceed? (Y/n)"
+of the wireless chip firmware has to be enabled. Do you want to proceed? (Y/n)"
     read answer
 
     if [ "$answer" == "Y" ] || [ "$answer" == "y" ]; then
-        unbreak_ap_limit
+	cd "$IOTEMPOWER_LOCAL"
+        ./bin/unbreak_ap_limit
     else
         echo "NB! A maximum of 8 connected clients are supported without the use of minimal broadcom firmware."
     fi

--- a/bin/unbreak_ap_limit
+++ b/bin/unbreak_ap_limit
@@ -6,7 +6,7 @@
 # Author: Anton Slavin
 # Create date: 2024-01-25
 
-[ "$IOTEMPOWER_ACTIVE" = "yes" ] || { echo "IoTempower not active, aborting." 1>&2;exit 1; }
+# [ "$IOTEMPOWER_ACTIVE" = "yes" ] || { echo "IoTempower not active, aborting." 1>&2;exit 1; }
 
 minimal_firmware_path="/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
 default_firmware_path="/lib/firmware/brcm/brcmfmac43455-sdio.bin"
@@ -41,7 +41,7 @@ else
 fi
 
 # Everything OK and we can activate the minimal firmware by setting up a syslink to it
-echo "Replacing default firmware file with the minimal version. NB! sudo access is required for the following operation!
+echo "Replacing default firmware file with the minimal version. NB! sudo access is required for the following operation!"
 
 sudo ln -sf "$minimal_firmware_path" "$default_firmware_path"
 

--- a/bin/unbreak_ap_limit
+++ b/bin/unbreak_ap_limit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Un-break the 8 client AP limit on some RPi boards by activating "minimal" broadcom firmware, 
+# bumping the new limit up to 20.
+#
+# Author: Anton Slavin
+# Create date: 2024-01-25
+
+[ "$IOTEMPOWER_ACTIVE" = "yes" ] || { echo "IoTempower not active, aborting." 1>&2;exit 1; }
+
+
+# First gather some version information
+raspberry_pi_version=$(cat /proc/cpuinfo | grep Model | awk -F ': ' '{print $2}')
+
+# Check if the version matches 3A+, 4, or 5
+if [[ "$raspberry_pi_version" =~ "Raspberry Pi 3 Model A+" || "$raspberry_pi_version" =~ "Raspberry Pi 4" || "$raspberry_pi_version" =~ "Raspberry Pi Zero 2 W" ]]; then
+    echo "This Raspberry Pi board is supported, going on..."
+else
+    echo "This Raspberry Pi board is not supported! Abandoning operation"
+    exit
+fi
+
+minimal_firmware_path="/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
+default_firmware_path="/lib/firmware/brcm/brcmfmac43455-sdio.bin"
+
+if [ -e "$minimal_firmware_path" ]; then
+    echo "Minimal firmware file found, going on..."
+else
+    echo "No correct version of minimal firmware found! Abandoning operation"
+    exit
+fi
+
+# Now check some paths to see if we have the right firmware in use right now
+# ...
+
+# Minimal firmware is already activated, exit
+# ...
+
+
+# Everything OK and we can activate the minimal firmware by setting up a syslink to it
+# ...
+echo "Replacing default firmware file with the minimal version. NB! sudo access is required for the following operation!
+
+sudo ln -sf $minimal_firmware_path $default_firmware_path
+
+
+# Finally, need a reboot to finalize things
+echo "A reboot of your device is required to active the new minimal firmware version"
+# ...

--- a/bin/unbreak_ap_limit
+++ b/bin/unbreak_ap_limit
@@ -8,6 +8,18 @@
 
 [ "$IOTEMPOWER_ACTIVE" = "yes" ] || { echo "IoTempower not active, aborting." 1>&2;exit 1; }
 
+minimal_firmware_path="/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
+default_firmware_path="/lib/firmware/brcm/brcmfmac43455-sdio.bin"
+
+# Check if we have the right firmware in use right now already
+symlink_check=$(readlink -f "$default_firmware_path")
+
+if [[ $symlink_check == *"minimal"* ]]; then
+  # Minimal firmware is already activated, exit
+  echo "The minimal firmware version is already activated! Abandoning operation"
+  exit
+fi
+
 
 # First gather some version information
 raspberry_pi_version=$(cat /proc/cpuinfo | grep Model | awk -F ': ' '{print $2}')
@@ -20,9 +32,7 @@ else
     exit
 fi
 
-minimal_firmware_path="/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
-default_firmware_path="/lib/firmware/brcm/brcmfmac43455-sdio.bin"
-
+# Check if the required firmware file exists on this system
 if [ -e "$minimal_firmware_path" ]; then
     echo "Minimal firmware file found, going on..."
 else
@@ -30,20 +40,12 @@ else
     exit
 fi
 
-# Now check some paths to see if we have the right firmware in use right now
-# ...
-
-# Minimal firmware is already activated, exit
-# ...
-
-
 # Everything OK and we can activate the minimal firmware by setting up a syslink to it
-# ...
 echo "Replacing default firmware file with the minimal version. NB! sudo access is required for the following operation!
 
-sudo ln -sf $minimal_firmware_path $default_firmware_path
-
+sudo ln -sf "$minimal_firmware_path" "$default_firmware_path"
 
 # Finally, need a reboot to finalize things
-echo "A reboot of your device is required to active the new minimal firmware version"
-# ...
+echo "Done!"
+echo "A reboot of your device is required to active the new minimal firmware version."
+echo "Please make sure to do so before using the Access Point."


### PR DESCRIPTION
Created a new script called "unbreak_ap_limit" to handle the activation of a minimal firmware file for the wireless chip.
The following steps are completed by the script:

1) A check is made to see if the minimal firmware file is already activated (exit if it is).
2) RPi board edition check is made, as only 3A+, 4, and 5 are supported (exit otherwise).
3) A check is made to see if the minimal firmware file exists at the correct location (exit otherwise).
4) The minimal firmware file is syslinked to the general firmware file path (requires sudo).

Also, the iot install script is modified to include a new section dedicated to running unbreak_ap_limit script.
User is queried about whether they would want to activate this modification, and the script is run if the answer is positive.