### PR TITLE
Fix issue - Clean up Mac support #83

### DIFF
--- a/bin/user_menu.js
+++ b/bin/user_menu.js
@@ -145,7 +145,16 @@ async function choice(items, pre_select=0, pad_last=0) {
 }
 
 function run_command(command, directory = null) {
-    var args = ['-q', '-e', '-c', command, '/dev/null' ];
+    // check for Mac OSX and skip '-c' (command) flag because the Darwin/BSD version
+    // of the script tool does not use this flag!
+    // Darwin/BSD style: script [-aeFfkqr] [-t time] [file [command ...]]
+    // therefore, /dev/null at the end is handled as input to the command and not as redirection of file.
+    var opsys = process.platform;
+    if (opsys == "darwin") {
+        var args = ['-q', '-e', '/dev/null', command ];  
+    } else {
+        var args = ['-q', '-e', '-c', command, '/dev/null' ];
+    }
 //    if(directory)
 //        cmd = 'cd "' + directory + '"; ' + cmd;
     term.wrap("\nRunning ", command, "\n\n");


### PR DESCRIPTION
Instead of trying to build a new script tool, I changed the code in user_menu.js / run_command() such that 
if the os is 'darwin' then the command is build following the rules for the BSD/Darwin version.

The -c flag is ignored and the file is set to /dev/null:

Darwin/BSD style: script [-aeFfkqr] [-t time] [file [command ...]]

If, like in the case of Linux systems, /dev/null is at the end, it will cause 'permission denied' because
it is given to the command as argument.