### PR TITLE
update image link/checksum for 2024_v2 version

### DIFF
--- a/doc/image-pi.rst
+++ b/doc/image-pi.rst
@@ -9,7 +9,7 @@ Make sure to resize the image at one point with the DietPi tools
 (DietPi-Drive_Manager -> / -> Resize).
 
 - Download the 64 Bit Raspberry Pi (only Pi 4 and probably Pi 3) image:
-  `iotgateway-pi64.img.xz <https://drive.google.com/file/d/1zz-bvu_x7rynVBTDSdJqs3SnXT4-cLyP>`_ 
+  `iotgateway2024_v2.img.xz <https://drive.google.com/file/d/1PMG5RvH36KjrTJvraiiEV34nhFETPCpk>`_ 
   from Google Drive.
 
   The old 32 bit version for pi 1-2 and zero (needs to be updated) is
@@ -17,7 +17,7 @@ Make sure to resize the image at one point with the DietPi tools
   sha256sum: ``f3be2ba597f2b885eb573a8c8af14e7cf788d614d765ae99ae0223c4f887454a``
   
 - Make sure the sha256-checksum of the 64 Bit image is correct. It should be:
-  ``057a3178bf69daea76dd10cb4904f2c56d4037a92ecd48b62c5a39e6948be442``
+  ``5d2fc222a6a303e23ed049485b515271394d3e66a46a151e4bcba99257a34482``
 
   On Linux and MacOS, you can use ``sha256sum`` or ``shasum -a 256`` to verify
   the image, on Windows you can use


### PR DESCRIPTION
the filename doesn't contain pi64 anymore but I think this is okay.
I think the old pi1/2 image link could be removed?