### PR TITLE
Update labels.yml: add documentation label, color and description

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -15,6 +15,10 @@
   color: "a2eeef"
   description: "New feature or request"
 
+- name: documentation
+  color: "007acc"
+  description: "Related to project documentation"
+
 - name: good first issue
   color: "7057ff"
   description: "Good for newcomers"


### PR DESCRIPTION
Quick patch branch merge to iotempower/master that adds a `documentation` label:
related project issue item: https://github.com/iotempire/iotempower/issues/125

adding this new label may help distinguish issues explicitly pertaining to documentation 