### PR TITLE
update scd4x: expose temp offset & altitude config + docs entry update

### DIFF
--- a/doc/node_help/ens16x.rst
+++ b/doc/node_help/ens16x.rst
@@ -1,6 +1,8 @@
 Sensirion ENS16X CO2 sensor
 ===========================
 
+TODO
+
 ..  code-block:: cpp
 
     ens16x(name)[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];

--- a/doc/node_help/scd4x.rst
+++ b/doc/node_help/scd4x.rst
@@ -3,7 +3,7 @@ Sensirion SCD4X CO2 sensor
 
 ..  code-block:: cpp
 
-    scd4x(name[, temp_comp][, altitude])[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];
+    scd4x(name[, temp_comp[, altitude]] )[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];
 
 Create a new scd4x co2 sensor device.
 

--- a/doc/node_help/scd4x.rst
+++ b/doc/node_help/scd4x.rst
@@ -3,7 +3,7 @@ Sensirion SCD4X CO2 sensor
 
 ..  code-block:: cpp
 
-    scd4x(name, temp_comp, altitude)[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];
+    scd4x(name[, temp_comp][, altitude])[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];
 
 Create a new scd4x co2 sensor device.
 
@@ -49,7 +49,7 @@ Parameters
     - Inside the code it can be addressed via ``IN(name)``.
 
 
-- ``temp_comp``
+- ``temp_comp`` (optional; default = 4.0)
     - 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_𝑎𝑐𝑡𝑢𝑎𝑙 = 𝑇𝑆𝐶𝐷4𝑥 − 𝑇𝑅𝑒𝑓𝑒𝑟𝑒𝑛𝑐𝑒 + 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_ 𝑝𝑟𝑒𝑣𝑖𝑜𝑢𝑠
     - Temperature offset helps optimize Relative Humidity and Temperature measurements.
     - Temperature offset depends on the measurement mode, self-heating of nearby components, ambient temperature and air flow. 
@@ -57,7 +57,7 @@ Parameters
     - Inside the code it can be addressed via ``IN(temp_comp)``.
 
 
-- ``altitude``
+- ``altitude`` (optional; default = 57)
     - Typically, the sensor altitude is set once after device installation. 
     - The default sensor altitude value is set to 0 meters above sea level. 
     - Valid input values are between 0 to 3000 m. 

--- a/doc/node_help/scd4x.rst
+++ b/doc/node_help/scd4x.rst
@@ -3,7 +3,7 @@ Sensirion SCD4X CO2 sensor
 
 ..  code-block:: cpp
 
-    scd4x(name)[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];
+    scd4x(name, temp_comp, altitude)[.i2c(sda,scl)][.with_address(i2c_address)][.with_filter(filter)];
 
 Create a new scd4x co2 sensor device.
 
@@ -49,6 +49,21 @@ Parameters
     - Inside the code it can be addressed via ``IN(name)``.
 
 
+- ``temp_comp``
+    - 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_𝑎𝑐𝑡𝑢𝑎𝑙 = 𝑇𝑆𝐶𝐷4𝑥 − 𝑇𝑅𝑒𝑓𝑒𝑟𝑒𝑛𝑐𝑒 + 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_ 𝑝𝑟𝑒𝑣𝑖𝑜𝑢𝑠
+    - Temperature offset helps optimize Relative Humidity and Temperature measurements.
+    - Temperature offset depends on the measurement mode, self-heating of nearby components, ambient temperature and air flow. 
+    - Recommend determining offset when installed and running under typical operational conditions and in thermal equilibrium.
+    - Inside the code it can be addressed via ``IN(temp_comp)``.
+
+
+- ``altitude``
+    - Typically, the sensor altitude is set once after device installation. 
+    - The default sensor altitude value is set to 0 meters above sea level. 
+    - Valid input values are between 0 to 3000 m. 
+    - Inside the code it can be addressed via ``IN(altitude)``.
+
+
 - ``.i2c(sda,scl)``
     - override i2c default ports - if not specified uses default i2c ports.
     - For the **M5StickC**, please use ``.i2c(32, 33)``.
@@ -72,7 +87,8 @@ Node name: ``room/gas``:
 
 ..  code-block:: cpp
 
-    scd4x(gas);
+    scd4x(gas, 5.0, 60); // name: room/gas, temp_comp: 5.0 [deg C], altitude: 60 [m]
+
 
 Now CO2 (in ppm), temperature (in deg C) and humidity (%RH) are published every 5 seconds as: 
 ``room/gas/co2ppm``, ``room/gas/temp``,  ``room/gas/humidity``.
@@ -82,7 +98,7 @@ Now CO2 (in ppm), temperature (in deg C) and humidity (%RH) are published every 
 
 ..  code-block:: cpp
 
-    scd4x(gas).i2c(32, 33);
+    scd4x(gas, 5.0, 60).i2c(32, 33); //for the M5StickC
 
 
 Wiring

--- a/lib/node_types/esp/src/dev_ens16x.cpp
+++ b/lib/node_types/esp/src/dev_ens16x.cpp
@@ -1,5 +1,5 @@
 // dev_ens16x.cpp
-
+//WIP
 #include "dev_ens16x.h"
 
 Ens16x::Ens16x(const char *name) : I2C_Device(name) {

--- a/lib/node_types/esp/src/dev_ens16x.cpp
+++ b/lib/node_types/esp/src/dev_ens16x.cpp
@@ -1,5 +1,5 @@
 // dev_ens16x.cpp
-//WIP
+//TODO
 #include "dev_ens16x.h"
 
 Ens16x::Ens16x(const char *name) : I2C_Device(name) {

--- a/lib/node_types/esp/src/dev_scd4x.cpp
+++ b/lib/node_types/esp/src/dev_scd4x.cpp
@@ -3,12 +3,15 @@
 
 DFRobot_SCD4X DFR_SCD4X(&Wire, SCD4X_I2C_ADDR);
 
-Scd4x::Scd4x(const char* name) : I2C_Device(name) {
+Scd4x::Scd4x(const char* name, const float temp_comp, const uint16_t altitude)
+    : I2C_Device(name) {
     set_pollrate(5000);  // 5 seconds
     add_subdevice(new Subdevice(F("CO2ppm")));
     add_subdevice(new Subdevice(F("temp")));
     add_subdevice(new Subdevice(F("humidity")));
     set_address(0x62);
+    _temp_comp = temp_comp;
+    _altitude = altitude;
 }
 
 void Scd4x::i2c_start() {
@@ -21,9 +24,14 @@ bool Scd4x::measure() {
         if (DFR_SCD4X.begin()) {  // start sensor, return true if success
             DFR_SCD4X.enablePeriodMeasure(
                 SCD4X_STOP_PERIODIC_MEASURE);  // stop measuring; 500ms delay
-            DFR_SCD4X.setTempComp(0.0);        // set temperature compensation
-            DFR_SCD4X.setSensorAltitude(57);   // set altitude 57m ASL Tartu, EE
+            DFR_SCD4X.setTempComp(
+                _temp_comp);  // set temperature compensation w/ offset
+            DFR_SCD4X.setSensorAltitude(
+                _altitude);  // set altitude, for example, 57m ASL Tartu, EE
             DFR_SCD4X.setAutoCalibMode(true);  // enable auto calibration
+            // DFR_SCD4X.persistSettings(); // Save the settings into EEPROM,
+            // default to be in RAM; not recommended - initialised every time,
+            // avoid wearing out the EEPROM
             DFR_SCD4X.enablePeriodMeasure(
                 SCD4X_START_PERIODIC_MEASURE);  // start measuring; 500ms delay
             _in_init_phase = false;

--- a/lib/node_types/esp/src/dev_scd4x.h
+++ b/lib/node_types/esp/src/dev_scd4x.h
@@ -5,6 +5,7 @@
 #define _IOTEMPOWER_SCD4X_H_
 
 #include <i2c-device.h>
+
 #include "DFRobot_SCD4X.h"
 
 extern DFRobot_SCD4X DFR_SCD4X;
@@ -12,9 +13,12 @@ extern DFRobot_SCD4X DFR_SCD4X;
 class Scd4x : public I2C_Device {
    private:
     bool _in_init_phase = false;
+    float _temp_comp;
+    uint16_t _altitude;
 
    public:
-    Scd4x(const char* name);
+    Scd4x(const char* name, const float temp_comp = 4.0,
+          const uint16_t altitude = 57);
     void i2c_start();
     bool measure();
 };


### PR DESCRIPTION
update scd4x: expose temp offset & altitude config + docs entry update
docs:
![image](https://github.com/user-attachments/assets/39742a19-6fb9-477e-9b19-b942899bd20d)

![image](https://github.com/user-attachments/assets/c4f74edf-3a33-4e65-bd63-f5000eebe01d)
header:
![image](https://github.com/user-attachments/assets/d8d486e0-f364-4b3b-bb7e-30ef70bc8c10)
cpp:
![image](https://github.com/user-attachments/assets/6617b44c-75aa-48b6-9cb3-cd70c9918590)
![image](https://github.com/user-attachments/assets/03420987-0286-40ec-9a13-ae6e7bc81b3f)
ignore the ens16x test edit (WIP...) .-.