### PR TITLE
Include AP configurator system library

### DIFF
--- a/lib/ap_configurator/ap_configurator.py
+++ b/lib/ap_configurator/ap_configurator.py
@@ -1,0 +1,204 @@
+#!/usr/bin/python3
+
+
+# Textual
+from textual import log
+from textual.app import App, ComposeResult
+from textual.containers import VerticalScroll, Grid
+from textual.widgets import Button, Header, Footer, Static, OptionList, Input, RadioButton, RadioSet, Label, Log
+from textual.widgets.option_list import Option, Separator
+from textual.reactive import reactive
+from textual.message import Message
+from textual.widgets import Markdown
+from textual.screen import Screen
+from textual import events
+
+# Python libraries
+import asyncio
+import platform
+import sys
+
+# Modules
+import config
+from utils import update_static, validate_config_params, run_cmd_async
+from screens import ConnectedClients, LocalConfiguration, OpenWRTConfiguration, APSettings, WiFiChipInfo, QuitScreen, RestartScreen
+
+
+
+class APConfigurator(App):
+    """
+    Access point configuration app
+    
+    This is the main UI class, containing the main menu screen 
+    and references to all other screens and functionality.
+    """
+
+    CSS_PATH = "style.tcss"
+    BINDINGS = [("q", "quit", "Quit")]
+    #dark = False
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with VerticalScroll():
+            yield Markdown("""
+# APConfigurator
+
+This application will help you automatically configure
+your Access Point and network settings.
+            """)
+
+            yield Static("", id="detected-chip")
+            yield Static("", id="iotemp-status")
+            yield Static("", id="softap-status")
+            yield OptionList(
+                Option("Configure Access Point", id="cap"),
+                Option("Configure OpenWRT Router", id="cor"),
+                Separator(),
+                Option("View Connected Clients", id="vcc"),
+                Option("View AP Settings", id="vas"),
+                Option("View Wi-Fi Chip Information", id="vci"),
+                Separator(),
+                Option("Quit", id="vq"),
+                id="menu"
+            )
+        yield Footer()
+        
+
+    def on_mount(self) -> None:
+        self.install_screen(ConnectedClients(), name="concli")
+        self.install_screen(LocalConfiguration(), name="localconf")
+        self.install_screen(OpenWRTConfiguration(), name="wrtconf")
+        self.install_screen(APSettings(), name="apsettings")
+        self.install_screen(WiFiChipInfo(), name="wifichipinfo")
+
+        asyncio.create_task(self.update_detected_chip())
+        asyncio.create_task(self.check_iotempower())
+        asyncio.create_task(self.check_running_ap())
+
+
+    def confirm_chip(self, detected) -> str:
+        """Detect chip manufacturer and active AP software from long info string, 
+        as returned by scripts/detect_wifi_chip.sh"""
+
+        config.WIFI_CHIP_FULL = detected
+        detected = detected.lower()
+
+        if 'netman_available' in detected:
+            config.SOFTAP = 'networkmanager'
+        if 'hostapd_available' in detected:
+            config.SOFTAP = 'hostapd'
+
+        if any(x in detected for x in ['brcm', 'broadcom', 'bcm']):
+            return 'Broadcom'
+        if any(x in detected for x in ['iwlwifi', 'intel']):
+            return 'Intel'
+        if any(x in detected for x in ['rtl', 'realtek']):
+            return 'Realtek'
+        if any(x in detected for x in ['ath9k', 'ath10k', 'ath11k']):
+            return 'Atheros'
+        if any(x in detected for x in ['mediatek', 'mt79', 'rt53', 'rt35', 'mt76']):
+            return 'MediaTek'
+
+        return ''
+
+
+    async def on_option_list_option_selected(self, message: OptionList.OptionSelected) -> None:
+        await self.handle_option(message.option.id)
+
+
+    async def handle_option(self, option_id: str) -> None:
+        # Don't allow accessing any of the screens if IoTempower is not activated,
+        # most of the scripts will not work
+        if not config.IOTEMPOWER and not option_id == "vq":
+            self.push_screen(QuitScreen())
+            return
+
+        if option_id == "cap":
+            self.push_screen('localconf')
+        elif option_id == "cor":
+            self.push_screen('wrtconf')
+        elif option_id == "vcc":
+            self.push_screen('concli')
+        elif option_id == "vas":
+            asyncio.create_task(self.check_running_ap())
+            self.push_screen('apsettings')
+        elif option_id == "vci":
+            self.push_screen('wifichipinfo')
+        elif option_id == "dap":
+            await run_cmd_async(f'bash ./scripts/turn_off_ap.sh {config.AP_SSID}', bg=True)
+            self.push_screen(RestartScreen())
+            pass
+        elif option_id == "vq":
+            self.action_quit()
+
+
+    async def update_detected_chip(self) -> None:
+        # Run the main chip info detection script
+        out,err = await run_cmd_async("bash ./scripts/detect_wifi_chip.sh")
+
+        # Gather separate information on the system
+        plfrm = platform.machine() + '-' + platform.platform(aliased=True, terse=True) + '-' + platform.system() + '-' + platform.processor()
+        config.SYSTEM = plfrm
+
+        if out and (chip := self.confirm_chip(out)):
+            config.WIFI_CHIP = chip
+            result = '\t[+] Your Wi-Fi chip: ' + chip
+        else:
+            result = '\t[!] Unable to detect your Wi-Fi chip.'
+
+        update_static(self, 'detected-chip', result)
+
+        # Also detect and set name of output device
+        out,err = await run_cmd_async("bash ./scripts/detect_dev_name.sh")
+        if out:
+            config.WDEVICE = out.strpip()
+            update_static(self, 'detected-chip', f', output device: {out}', append=True)
+
+
+    async def check_running_ap(self) -> None:
+        # First, check if any saved credentials already exist
+        out1,err1 = await run_cmd_async("bash ./scripts/read_wifi_creds.sh")
+        creds = out1.strip()
+        if out1 and len(creds) > 2 and ',' in creds:
+            cl = creds.split(',')
+            config.AP_SSID = cl[0].strip()
+            config.AP_IP = cl[2].strip()
+
+
+        # Check whether hostapd has been activated already
+        out,err = await run_cmd_async("ps -a | grep 'hostapd\\|create_ap'")
+
+        if 'hostapd' in out:
+            config.AP_RUNNING = 'hostapd'
+        else:
+            # Check NM service status separately
+            out,err = await run_cmd_async("nmcli con show --active")
+            if not err and out and config.AP_SSID and config.AP_SSID in out:
+                config.AP_RUNNING = 'NetworkManager'
+
+        if config.AP_RUNNING:
+            update_static(self, 'softap-status', '\t[+] An active AP has been detected: ' + config.AP_RUNNING)
+            self.query_one('#menu').add_option(Option("Turn Off Active AP", id="dap"))
+
+
+    async def check_iotempower(self) -> None:
+        # Check whether IoTempower environment is activated
+        out,err = await run_cmd_async('bash ./scripts/detect_iotempower.sh')
+
+        config.IOTEMPOWER = out.strip() == 'yes'
+
+        status = "\t[+] IoTempower is installed correctly and activated" if config.IOTEMPOWER else "\t[-] IoTempower is not activated! Functionality is not available!"
+
+        update_static(self, 'iotemp-status', status)
+
+        if not config.IOTEMPOWER:
+            self.push_screen(QuitScreen())
+
+
+    def action_quit(self) -> None:
+        self.exit()
+
+
+if __name__ == "__main__":
+    app = APConfigurator()  
+    app.run()

--- a/lib/ap_configurator/config.py
+++ b/lib/ap_configurator/config.py
@@ -1,0 +1,12 @@
+# Shared configuration and state variables
+
+WIFI_CHIP = ''
+WIFI_CHIP_FULL = ''
+SYSTEM = ''
+SOFTAP = '--'
+AP_RUNNING = ''
+IOTEMPOWER = ''
+WDEVICE = 'wlan0'
+BASEIP = '192.168.12.1'
+AP_SSID = ''
+AP_IP = ''

--- a/lib/ap_configurator/run.sh
+++ b/lib/ap_configurator/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+# Launcher for the AP Configurator app
+
+# Usage:
+# bash run.sh, or
+# ./run.sh
+
+
+echo "Testing sudo rights for this user..."
+sudo echo "OK"
+sudo echo "Launching app..."
+python3 ./ap_configurator.py

--- a/lib/ap_configurator/screens.py
+++ b/lib/ap_configurator/screens.py
@@ -1,0 +1,437 @@
+#!/usr/bin/python3
+
+
+# Textual
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.containers import Grid, VerticalScroll
+from textual.widgets import Button, Header, Footer, Static, Input, RadioButton, RadioSet, Log, Markdown, Label
+
+# Python libraries
+import asyncio
+
+# Modules
+import config
+from utils import update_static, validate_config_params, run_cmd_async, extract_keywords
+
+
+
+class ConnectedClients(Screen):
+    """Show the currently connected clients"""
+
+    BINDINGS = [("m", "app.pop_screen", "Back to Menu")]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with VerticalScroll():
+            yield Markdown("""
+# Connected Clients
+
+This tool will detect all clients connected to an active AP and discoverable over MQTT.
+                """)
+            yield Markdown(f"""
+                """, id="scanres")
+            yield Button("Scan", id="scan-btn", classes="buttons")
+        yield Footer()
+
+
+    async def run_arp_scan(self, dev):
+        out,err = await run_cmd_async(f"sudo arp-scan --localnet --interface={dev}")
+
+        lines = out.split('\n')
+        start_index = -1
+        end_index = -1
+
+        for index, line in enumerate(lines):
+            if line.startswith('Starting arp-scan'):
+                start_index = index
+            elif line.endswith('packets dropped by kernel'):
+                end_index = index
+                break
+
+        macs = lines[start_index+1:end_index-1] if start_index != -1 and end_index != -1 else []
+        out = {}
+        for m in macs:
+            row = m.split('\t')
+            out[row[0]] = row[1] # IP, MAC
+
+        return out
+
+
+    async def run_get_ips(self, dev):
+        out,err = await run_cmd_async('get_ips')
+        lines = out.split('\n')
+
+        macs = await self.run_arp_scan(dev)
+        out = {}
+        for line in lines[1:]:
+            if not line: 
+                continue
+            line = line.split(': ')
+            ip = line[1]
+            name = line[0]
+            if ip in macs.keys():
+                out[name] = [ip, macs[ip]]
+
+        return out
+
+
+    async def check_connected_clients(self) -> None:
+        out = await self.run_get_ips(config.WDEVICE)
+        out_formatted = ''
+        for k,v in out.items():
+            out_formatted += f'| {k} | {v[0]} | {v[1]} |\n'
+
+        self.query_one('#scanres', Markdown).update(f"""
+| Name      | IP | MAC |
+| ----- | ----- | ----- | 
+{out_formatted}
+
+
+Total clients: {len(out.keys())}
+            """)
+
+
+    def on_mount(self):
+        pass
+
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.query_one('#scanres', Markdown).update("""
+Running scan...
+""")
+        asyncio.create_task(self.check_connected_clients())
+
+
+
+
+class LocalConfiguration(Screen):
+    """
+    Local AP configuration using hostapd or NetworkManager
+
+    User input is collected for the SSID and password, 
+    and a live log is shown to document the process.
+
+    Using IoTempower scripts: accesspoint and accesspoint-nm
+    """
+
+    BINDINGS = [("m", "app.pop_screen", "Back to Menu")]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+
+        with VerticalScroll():
+            yield Markdown("""
+# Configure Access Point
+                """)
+
+            yield Static('\tSoftware:')
+            with RadioSet(id='ap_backend'):
+                yield RadioButton("hostapd", id="hostapd", value=True)
+                yield RadioButton("NetworkManager", value=False, id='networkmanager')
+
+            yield Static('\tThe name for the network:')
+            yield Input(placeholder="Network Name", id='ssid')
+            yield Static('\tPassword for the network:')
+            yield Input(placeholder="Password", password=True, id='netpass')
+            yield Static('\tPassword confirmation:')
+            yield Input(placeholder="Password", password=True, id='netpass2')
+            yield Static(f'\n\tThe default IP address of {config.BASEIP} will be used for the network.')
+            yield Button("Configure", id="config-btn", classes="buttons")
+            yield Log('\t\n', id="status", auto_scroll=True)
+        yield Footer()
+
+
+    def on_mount(self):
+        # Disable creating a new AP if one is running already
+        if config.AP_RUNNING:
+            log = self.query_one(Log)
+            log.clear()
+            log.write_line('Access point is already running on this system!')
+            self.query_one('#config-btn', Button).disabled = True
+
+
+    async def configure_local(self) -> None:
+        # Collect user input
+        backend = self.query_one('#ap_backend').pressed_button.id
+        nname = self.query_one('#ssid').value
+        npass = self.query_one('#netpass').value
+        npass2 = self.query_one('#netpass2').value
+
+        log = self.query_one(Log)
+
+        # Validate
+        if not validate_config_params(log, backend, nname, npass, npass2):
+            return
+
+        log.clear()
+        log.write_line('Starting configuration...')
+        self.query_one('#config-btn', Button).disabled = True
+        
+        # Apply broadcom minimal firmware patch
+        if config.WIFI_CHIP == 'Broadcom' or True:
+            log.write_line('Attempting to activate minimal firmware for your Wi-Fi chip...')
+
+            out,err = await run_cmd_async("bash ./scripts/activate_brcm_minimal.sh")
+            log.write_line(out)
+            log.write_line(err)
+        
+
+        # Launch MQTT right away
+        log.write_line('Starting MQTT server...')
+        await run_cmd_async(f"bash ./scripts/iot_mqtt_start.sh", bg=True)
+
+        # Start AP configuration
+        if backend == 'hostapd':
+            log.write_line('Running hostapd setup...')
+            log.write_line('Please wait up to 30 seconds for the AP to start')
+            await run_cmd_async(f"bash ./scripts/iot_hp_setup.sh {nname} {npass} {config.BASEIP} {config.WDEVICE}", bg=True)
+        
+        elif backend == 'networkmanager':
+            log.write_line('Running NetworkManager setup...')
+            out,err = await run_cmd_async(f"bash ./scripts/iot_nm_setup.sh {nname} {npass} {config.BASEIP} '/24' {config.WDEVICE}")
+            log.write_line(out)
+            if err:
+                log.write_line('\nNB! Please restart your device to activate the AP!')
+
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        asyncio.create_task(self.configure_local())
+
+
+
+
+class OpenWRTConfiguration(Screen):
+    """
+    OpenWRT router automatic configuration
+
+    User input is collected for the SSID and password, 
+    and a live log is shown to document the process.
+
+    Using IoTempower scripts: wifi_openwrt_uci, setup_systemconf
+    """
+
+    BINDINGS = [("m", "app.pop_screen", "Back to Menu")]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+
+        with VerticalScroll():
+            yield Markdown("""
+# Configure OpenWRT Router
+
+Make sure your router has the following requirements met:
+
+- OpenWRT version 21 and newer supported
+- At least 16MB of memory available
+- An SSH connection can be made to the router
+
+Before starting, please do the following steps:
+
+- Connect the router to Internet
+- Connect this device to the router over Ethernet
+
+Then, follow the instructions as they appear in the screen below.
+            """)
+
+            yield Static('\tThe name for the network:')
+            yield Input(placeholder="Network Name", id='ssid')
+            yield Static('\tPassword for the network:')
+            yield Input(placeholder="Password", password=True, id='netpass')
+            yield Static('\tPassword confirmation:')
+            yield Input(placeholder="Password", password=True, id='netpass2')
+            yield Button("Configure", id="config-btn", classes="buttons")
+            yield Log('\t\n', id="status")
+        yield Footer()
+
+
+    async def configure_openwrt(self) -> None:
+        # Collect user input
+        nname = self.query_one('#ssid').value
+        npass = self.query_one('#netpass').value
+        npass2 = self.query_one('#netpass2').value
+        
+
+        log = self.query_one(Log)
+
+        if not validate_config_params(log, True, nname, npass, npass2):
+            return
+
+        log.clear()
+        log.write_line('Starting configuration...')
+        self.query_one('#config-btn', Button).disabled = True
+
+        out,err = await run_cmd_async(f"bash ./scripts/iot_openwrt_setup.sh {nname} {npass} {config.BASEIP}")
+        log.write_line(out)
+        log.write_line(err)
+
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        asyncio.create_task(self.configure_openwrt())
+
+
+
+
+class APSettings(Screen):
+    """
+    Display AP configuration
+
+    Show the pre-configured credentials of an AP and more general
+    network settings on this system  
+    """
+
+    BINDINGS = [("m", "app.pop_screen", "Back to Menu")]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with VerticalScroll():
+            yield Markdown(f"""
+# Access Point Settings
+            """)
+        yield Footer()
+
+
+    async def read_credentials(self) -> None:
+        ssid = '--'
+        if config.AP_SSID:
+            ssid = config.AP_SSID
+
+        ip = '--'
+        if config.AP_IP:
+            ip = config.AP_IP
+
+        ap_run = 'False'
+        if config.AP_RUNNING:
+            ap_run = config.AP_RUNNING
+        
+        self.query_one(Markdown).update(f"""
+# Access Point Settings
+
+The following Wi-Fi AP credentials can be found on your system:
+
+| Setting      | Value |
+| ----------- | ----------- |
+| Network name (SSID) | {ssid} |
+| IP address          | {ip}  |
+| Default IP for new APs | {config.BASEIP} |
+| Output wireless device | {config.WDEVICE}  |
+| IoTempower activated | {config.IOTEMPOWER} |
+| Access point running | {ap_run} |
+| Other AP software present on system | {config.SOFTAP} |
+
+            """)
+
+
+    def on_mount(self) -> None:
+        asyncio.create_task(self.read_credentials())
+
+
+
+
+class WiFiChipInfo(Screen):
+    """
+    Display Wi-Fi hardware and system information
+
+    Show any collected information about the current system,
+    and any Wi-Fi capable devices present on it  
+    """
+
+    BINDINGS = [("m", "app.pop_screen", "Back to Menu")]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with VerticalScroll():
+            yield Markdown(f"""
+# Wi-Fi Chip Information
+            """)
+
+        yield Footer()
+
+    async def load_info(self) -> None:
+        kwords = extract_keywords(config.WIFI_CHIP_FULL)
+        kword_filtered = ''
+        for kw in kwords:
+            key = kw[0].strip()
+            value = kw[1].strip()
+            if value:
+                if key == 'controller_subsystem' or key == 'pci_controller':
+                    value = '| Full device name: |' + value + '|'
+
+                elif key == 'kernel_driver_in_use':
+                    value = '| Driver in use: |' + value + '|'
+
+                elif key == 'cpuver':
+                    value = '| System model information: |' + value + '|'
+
+                else:
+                    continue
+
+                kword_filtered += value + '\n'
+
+        # Display the warning about limited clients on some Broadcom and Intel chips
+        chip_compat_warning = ''
+
+        if config.WIFI_CHIP == 'Broadcom':
+            chip_compat_warning = '## Notice\n\nIt appears that you have a Broadcom Wi-Fi chip with a potential limit of only **8** active clients, which means that any clients you attempt to connect after the 8th one will silently fail!\n\nA minimal firmare version is available, which might increase the client limit to **20**. The minimal firmware is activated automatically when creating an AP using this app.'
+        elif config.WIFI_CHIP == 'Intel':
+            chip_compat_warning = '## Notice\n\nIt appears that you have an Intel Wi-Fi chip on your system, some of which have a known upper client limit of **11** devices, which means that no more than 11 clients can be connected to your computer at the same time! Unfortunately, there is no simple workaround to this issue, so just keep this in mind.\n\nUsing an external OpenWRT-based Wi-Fi router is recommended. '
+
+
+        self.query_one(Markdown).update(f"""
+# Wi-Fi Chip Information
+
+| Setting      | Value |
+| ----------- | ----------- |
+| Chip manufacturer | {config.WIFI_CHIP} |
+{kword_filtered}| System info | {config.SYSTEM} |
+
+
+{chip_compat_warning}
+
+""")
+
+
+    def on_mount(self) -> None:
+        asyncio.create_task(self.load_info())
+
+
+
+
+class QuitScreen(Screen):
+    """
+    Screen with a dialog to quit
+    Used to block the app if IoTempower is not activated
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Grid(
+            Label("Please install and activate IoTempower before using this app!", id="question"),
+            Button("Quit", variant="error", id="quit"),
+            Button("Cancel", variant="primary", id="cancel"),
+            id="dialog",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "quit":
+            self.app.exit()
+        self.app.pop_screen()
+
+
+class RestartScreen(Screen):
+    """
+    Information dialog screen with request to restart app
+    Used after disabling the AP
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Grid(
+            Label("AP has been turned off. Please restart this app to continue!", id="question"),
+            Button("Quit", variant="primary", id="quit"),
+            Button("Cancel", id="cancel"),
+            id="dialog",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "quit":
+            self.app.exit()
+        self.app.pop_screen()

--- a/lib/ap_configurator/scripts/activate_brcm_minimal.sh
+++ b/lib/ap_configurator/scripts/activate_brcm_minimal.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+minimal_firmware_path="/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
+default_firmware_path="/lib/firmware/brcm/brcmfmac43455-sdio.bin"
+
+
+# if [[ ! -e minimal_firmware_path ]]; then
+#     echo "The minimal firmware file could not be found!"
+#     exit
+# fi
+
+# Check if we have the right firmware in use right now already
+symlink_check=$(readlink -f "$default_firmware_path")
+
+if [[ $symlink_check == *"minimal"* ]]; then
+  # Minimal firmware is already activated, exit
+  # TODO: suggest to undo the changes and bring back standard firmware
+  echo "The minimal firmware version is already activated! Abandoning operation"
+  exit
+fi
+
+
+# First gather some version information
+raspberry_pi_version=$(cat /proc/cpuinfo | grep Model | awk -F ': ' '{print $2}')
+
+# Check if the version matches 3A+, 4, or 5
+if [[ "$raspberry_pi_version" =~ "Raspberry Pi 3 Model A+" || "$raspberry_pi_version" =~ "Raspberry Pi 4" || "$raspberry_pi_version" =~ "Raspberry Pi Zero 2 W" ]]; then
+    echo "This Raspberry Pi board is supported, going on..."
+else
+    echo "This Raspberry Pi board is not supported! Abandoning operation"
+    exit
+fi
+
+# Check if the required firmware file exists on this system
+if [ -e "$minimal_firmware_path" ]; then
+    echo "Minimal firmware file found, going on..."
+else
+    echo "No correct version of minimal firmware found! Abandoning operation"
+    exit
+fi
+
+# Everything OK and we can activate the minimal firmware by setting up a syslink to it
+echo "Replacing default firmware file with the minimal version. NB! sudo access is required for the following operation!"
+
+# First remove the update-alternatives links for cyfmac, we're taking over
+sudo update-alternatives --quiet --remove-all cyfmac43455-sdio.bin
+
+sudo ln -sf "$minimal_firmware_path" "$default_firmware_path"
+
+
+echo "Reloading the firmware..."
+sudo rmmod brcmfmac
+sudo modprobe brcmfmac
+
+
+# Finally, need a reboot to finalize things
+echo "Done!"
+#echo "A reboot of your device is required to active the new minimal firmware version."
+#echo "Please make sure to do so before using the Access Point."

--- a/lib/ap_configurator/scripts/detect_dev_name.sh
+++ b/lib/ap_configurator/scripts/detect_dev_name.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+
+# Attempt to detect name of output Wireless device
+# Code borrowed from the "accesspoint" script in IoTempower, author: ulno
+
+
+OUTPUT_WIFI=""
+if [[ "$IOTEMPOWER_AP_DEVICES" ]]; then
+    available_wifi=$(echo $(ip link show|cut -d: -f2|grep " wl"|cut -b2-))
+    for possible in $(echo "$IOTEMPOWER_AP_DEVICES"); do
+        if [[ "$available_wifi" =~ .*"$possible".* ]]; then
+            OUTPUT_WIFI="$possible"
+            break
+        fi
+    done
+else
+    # Take first available
+    OUTPUT_WIFI=$(ip link show|cut -d: -f2|grep " wl"|cut -b2-|tail -n1)
+fi
+
+echo $OUTPUT_WIFI

--- a/lib/ap_configurator/scripts/detect_iotempower.sh
+++ b/lib/ap_configurator/scripts/detect_iotempower.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $IOTEMPOWER_ACTIVE

--- a/lib/ap_configurator/scripts/detect_wifi_chip.sh
+++ b/lib/ap_configurator/scripts/detect_wifi_chip.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+
+# An attempt to detect any relevant Wi-Fi chip/driver identifiers 
+# from the output of Linux system info tools: dmesg, lsusb, lspci, lshw.
+# Outputs a single string with any relevant bits combined together.
+
+filter_msg() {
+  # Arg $1 - Provided msg
+
+  # Common driver identifiers that we are interested in
+  local filter_str="ath9k|ath10k|ath11k|ath12k|broadcom|realtek|intel|mediatek|brcm|bcm|b43|mt76|mt79|rt35|rt53|iwlwifi|rtl|brcmfmac|brcmsmac"
+  
+  # Filter the given message for any of the keywords,
+  # save the ones present and discard duplicates
+  echo $1 | grep -iEo $filter_str | sort -u
+}
+
+
+# Kernel logs
+dmesg=$(filter_msg "$(dmesg)")
+
+# Gather status and capabilities,
+# join with lshw "logical name"
+#filter_msg "$(sudo iwconfig)"
+
+# Lookup from known/supported chips/vendors
+# from connected USB devices
+usb=$(filter_msg "$(lsusb)")
+
+# Lookup from known/supported chips/vendors
+pci=$(filter_msg "$(lspci -nn)")
+
+# Find "Wireless interface" and collect 
+# product, vendor, bus info, logical name, 
+# serial, capabilities and configuration.
+lshw_raw=$(lshw -html -C network)
+lshw=$(filter_msg "$lshw_raw")
+
+# Parse lshw's HTML output separately
+parsed_output=$(echo $lshw_raw | xmllint --html --xpath "
+  //div[contains(@class, 'indented') and 
+  div/table[@summary='attributes of network']/tbody/tr[td='Wireless interface']]/
+  div/table[@summary='attributes of network']/tbody/tr/td[@class='second']
+" - 2>/dev/null)
+
+# Extract the initial 6 fields, interested in the first three lines mostly
+awk_output=$(echo "$parsed_output" | awk '
+  BEGIN { RS="</td>"; FS="<td class=\"second\">"; } 
+  NF>1 { print $2 } 
+  NR==6 { exit }')
+
+lshw_config=$(lshw -C network | grep -i configuration)
+echo ";lshw_config:$lshw_config;"
+
+# Existing AP software detection
+hostapd "--version"
+hp1=$?
+
+nmcli "-v"
+nm1=$?
+
+hp_avail=""
+nm_avail=""
+if [ $hp1 -eq 0 ]; then
+  hp_avail="hostapd_available"
+fi
+
+if [ $nm1 -eq 0 ]; then
+  nm_avail="netman_available"
+fi
+
+# Separate pass over lspci to hopefully extract manufacturer, chip and driver name 
+lspci_output=$(lspci -v)
+
+subsystem=$(echo "$lspci_output" | awk '/Network controller/{f=1} f{if($0 ~ /Subsystem:/){print $0;f=0}}' | sed 's/Subsystem: //')
+pci=$(echo "$lspci_output" | awk '/Network controller/{f=1} f{if($0 ~ /PCI bridge:/){print $0;f=0}}' | sed 's/PCI bridge: //')
+kernel_driver=$(echo "$lspci_output" | awk '/Network controller/{f=1} f{if($0 ~ /Kernel driver in use:/){print $0;f=0}}' | sed 's/Kernel driver in use: //')
+
+echo ";controller_subsystem:$subsystem;"
+echo "pci_controller:$pci;"
+echo "kernel_driver_in_use:$kernel_driver;"
+
+# CPU info string, works well on RPis
+cpuver=$(cat /proc/cpuinfo | grep Model | awk -F ': ' '{print $2}')
+echo "cpuver:$cpuver;"
+
+lsmod_driver=$(lsmod | grep cfg80211)
+
+# Concatenate all outputs
+combined=$(echo -e "$awk_output,$dmesg,$usb,$pci,$lshw,$hp_avail,$nm_avail,$lsmod_driver" | sort | uniq)
+echo $combined

--- a/lib/ap_configurator/scripts/iot_hp_setup.sh
+++ b/lib/ap_configurator/scripts/iot_hp_setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+
+# hostapd AP setup with steps.
+# Based on accesspoint script in IoTempower, 
+# adjusted for interactive use
+
+nname=$1
+npass=$2
+baseip=$3
+wdevice=$4
+
+
+# Prepare for hostapd use after (presumably) NM
+sudo sed -i '/^\[ifupdown\]/{N;s/managed=true/managed=false/;}' "/etc/NetworkManager/NetworkManager.conf"
+# Remove a single '#' from line start if device name present 
+sudo sed -i "/^\(#.*\)\($wdevice\)/ s/^#//" "/etc/network/interfaces"
+
+sudo ifdown $wdevice && sudo ifup $wdevice
+sudo service NetworkManager restart
+
+
+export IOTEMPOWER_AP_NAME=$nname
+export IOTEMPOWER_AP_PASSWORD=$npass
+export IOTEMPOWER_AP_IP=$baseip
+export IOTEMPOWER_AP_ADDID="no"
+
+# Save to IoTempower config file as well,
+# granted the file is protected well
+cat << EOF > $IOTEMPOWER_ROOT/etc/wifi_credentials
+SSID=$nname
+Password=$npass
+GatewayIP=$baseip
+EOF
+
+
+# Call the iotempower script from bin/,
+# iot env must be activated!
+echo $(accesspoint)

--- a/lib/ap_configurator/scripts/iot_mqtt_start.sh
+++ b/lib/ap_configurator/scripts/iot_mqtt_start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mqtt_broker

--- a/lib/ap_configurator/scripts/iot_nm_setup.sh
+++ b/lib/ap_configurator/scripts/iot_nm_setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+
+# NetworkManager AP setup with steps.
+# Based on accesspoint-nm script in IoTempower, 
+# adjusted for interactive use
+
+nname=$1
+npass=$2
+baseip=$3
+netmask=$4
+wdevice=$5
+
+
+# Prepare for NM use after (presumably) hostapd
+
+echo 'polkit.addRule(function(action, subject) {
+    if (action.id.indexOf("org.freedesktop.NetworkManager.") == 0 && subject.user == "iot") {
+        return polkit.Result.YES;
+    }
+});' | sudo tee /etc/polkit-1/rules.d/50-nmcli.rules > /dev/null
+
+sudo sed -i '/^\[ifupdown\]/{N;s/managed=false/managed=true/;}' "/etc/NetworkManager/NetworkManager.conf"
+# Ensure that line does not start with '#', else add it if device name present
+sudo sed -i "/^\([^#]*$wdevice\)/ s/^/#/" "/etc/network/interfaces"
+
+sudo service NetworkManager restart
+
+
+# IoTempower handling the security aspect of the password entry!
+cat << EOF > $IOTEMPOWER_ROOT/etc/wifi_credentials
+SSID=$nname
+Password=$npass
+GatewayIP=$baseip
+EOF
+
+
+# Call the iotempower script from bin/,
+# iot env must be activated!
+echo $(accesspoint-nm create --ssid $nname --password $npass --ip $baseip --netmask $netmask)

--- a/lib/ap_configurator/scripts/iot_openwrt_setup.sh
+++ b/lib/ap_configurator/scripts/iot_openwrt_setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+
+# External OpenWRT router setup.
+# Based on wifi_setup_openwrt script in IoTempower,
+# adjusted for interactive use
+
+nname=$1
+npass=$2
+baseip=$3
+
+
+# IoTempower handling the security aspect of the password entry!
+cat << EOF > $IOTEMPOWER_ROOT/etc/wifi_credentials
+SSID=$nname
+Password=$npass
+GatewayIP=$baseip
+EOF
+
+
+echo $(wifi_openwrt_uci)
+echo $(setup_systemconf)

--- a/lib/ap_configurator/scripts/read_wifi_creds.sh
+++ b/lib/ap_configurator/scripts/read_wifi_creds.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+# Read previously defined AP credentials (if they exist)
+
+source $IOTEMPOWER_ROOT/etc/wifi_credentials
+
+echo "$SSID,$Password,$GatewayIP"

--- a/lib/ap_configurator/scripts/turn_off_ap.sh
+++ b/lib/ap_configurator/scripts/turn_off_ap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+# Turn off any running APs created by the app
+
+ssid=$1
+
+nmcli connection delete $ssid
+sudo service NetworkManager restart
+
+sudo pkill create_ap
+sudo pkill hostapd
+
+ps -ax | grep "$ssid" | grep -v grep | awk '{print $1}' | xargs -r sudo kill -9

--- a/lib/ap_configurator/scripts/wrt_mqtt_alive.sh
+++ b/lib/ap_configurator/scripts/wrt_mqtt_alive.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+BROKER_ADDRESS="192.168.12.1"
+BROKER_PORT=1883
+TEMP_FILE="/tmp/mqtt_clients"
+
+# Clear the temporary file
+> $TEMP_FILE
+
+# Function to update client timestamp
+update_client() {
+    local client_id="$1"
+    local timestamp=$(date +%s)
+    # Append or update the client timestamp
+    grep -v "^$client_id " $TEMP_FILE > $TEMP_FILE.tmp
+    echo "$client_id $timestamp" >> $TEMP_FILE.tmp
+    mv $TEMP_FILE.tmp $TEMP_FILE
+}
+
+# Function to count active clients
+count_active_clients() {
+    local current_time=$(date +%s)
+    local timeout=30  # 30 seconds timeout
+    local active_count=0
+
+    while read line; do
+        set -- $line
+        local last_seen=$2
+        if [ $(($current_time - $last_seen)) -le $timeout ]; then
+            active_count=$((active_count + 1))
+        fi
+    done < $TEMP_FILE
+
+    echo "Active clients: $active_count"
+}
+
+# Subscribe to all topics and process messages
+mosquitto_sub -h $BROKER_ADDRESS -p $BROKER_PORT -t "#" | while read line; do
+    local client_id=$(echo "$line" | cut -d '/' -f1)  # Assuming client_id is the first part of the topic
+    update_client "$client_id"
+    count_active_clients
+done

--- a/lib/ap_configurator/style.tcss
+++ b/lib/ap_configurator/style.tcss
@@ -1,0 +1,42 @@
+#menu {
+    margin: 4 8;
+    background: $panel;
+    color: $text;
+    border: tall $background;
+    padding: 1 2;
+}
+
+.buttons {
+    margin: 2 12;
+}
+
+Input, RadioSet, Log, Markdown {
+    margin: 1 12;
+}
+
+
+QuitScreen, RestartScreen {
+    align: center middle;
+}
+
+#dialog {
+    grid-size: 2;
+    grid-gutter: 1 2;
+    grid-rows: 1fr 3;
+    padding: 0 1;
+    width: 60;
+    height: 11;
+    border: thick $background 80%;
+    background: $surface;
+}
+
+#question {
+    column-span: 2;
+    height: 1fr;
+    width: 1fr;
+    content-align: center middle;
+}
+
+QuitScreen Button, RestartScreen Button {
+    width: 100%;
+}

--- a/lib/ap_configurator/utils.py
+++ b/lib/ap_configurator/utils.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+import asyncio
+from textual.widgets import Static
+import subprocess
+import re
+
+
+def update_static(screen, idd, text, append=False) -> None:
+    """
+    Utility function to update static screen object
+	
+	Used to update text on screen (once) after receiving it from an async function.
+    """
+
+    s = screen.query_one(f'#{idd}', Static)
+    newtext = text if not append else s.renderable + text
+    s.update(newtext)
+
+
+def validate_config_params(log, backend, nname, npass, npass2) -> bool:
+    """Validate the given params: SSID and password for an AP"""
+
+    if not backend or not nname or not npass or len(nname) < 2 or len(nname) > 32 or len(npass) < 8 or len(npass) > 128:
+        log.clear()
+        log.write_line('[!] Make sure your network name is valid and password has at least 8 characters!')
+        return False
+
+    if npass != npass2:
+        log.clear()
+        log.write_line('[!] The passwords do not match!')
+        return False
+
+    return True
+
+
+async def run_cmd_async(cmd, bg=False):
+    """Run the given command asynchronously and return output"""
+
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    # If bg=True, launch silently in background
+    if not bg:
+    	stdout, stderr = await proc.communicate()
+    	return stdout.decode(), stderr.decode()
+    else:
+    	proc.communicate()
+    	return None
+
+
+def extract_keywords(strng):
+	"""Given a string, extract keywords in the form of key:value;"""
+
+	pattern = r'(\w+):([^;]*)'
+	matches = re.findall(pattern, strng)
+	return matches


### PR DESCRIPTION
Importing the semi-automatic AP configuration system as a library in the "lib" folder, due to it being a separate Python app, with its own bash launcher.

Requires the installation of Textual (python package). Might be good to suggest this library during IoTempower installation?

Everything UI related is in Python files, all working modules are bash scripts inside the `scripts` subfolder. Also relying on IoTempower bin programs. _Some of the scripts might be replaced by native IoTempower /bin program calls later on as well, reducing the amount of redundant components._

Originally developed in this repository: [https://github.com/tonysln/msc](https://github.com/tonysln/msc) -- README can be found there too; MIT license. 