### PR TITLE
Fix ESP8266 MQTT TLS compatibility (cert SANs + trust-anchor parsing + low-memory publish stability)

### DIFF
--- a/bin/mqtt_generate_certificates
+++ b/bin/mqtt_generate_certificates
@@ -25,13 +25,35 @@ echo "$system_name"
 mkdir -p "$cert_path"
 cd "$cert_path" || { echo "Can't change to $cert_path. Aborting." 1>&2; exit 1; }
 
-openssl ecparam -genkey -name prime256v1 -out ca.key
-openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt -subj "/CN=${system_name}CA"
+# Use RSA certs for broad client compatibility (including ESP8266 TLS stacks).
+openssl genrsa -out ca.key 2048
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt \
+    -subj "/CN=${system_name}CA" \
+    -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign" \
+    -addext "subjectKeyIdentifier=hash"
 
-openssl ecparam -genkey -name prime256v1 -out server.key
+openssl genrsa -out server.key 2048
 openssl req -new -key server.key -out server.csr -subj "/CN=$IOTEMPOWER_MQTT_HOST"
 
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 3650 -sha256
+# Build SAN extension so modern TLS clients can verify host identity.
+# Include configured MQTT host and localhost aliases for local demos.
+san_file="server.ext"
+if [[ "$IOTEMPOWER_MQTT_HOST" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    cat > "$san_file" << EOF
+subjectAltName = IP:$IOTEMPOWER_MQTT_HOST,IP:127.0.0.1,DNS:localhost
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+EOF
+else
+    cat > "$san_file" << EOF
+subjectAltName = DNS:$IOTEMPOWER_MQTT_HOST,DNS:localhost,IP:127.0.0.1
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+EOF
+fi
+
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+    -out server.crt -days 3650 -sha256 -extfile "$san_file"
 
 openssl verify -CAfile ca.crt server.crt
-

--- a/lib/node_types/esp/platformio.ini
+++ b/lib/node_types/esp/platformio.ini
@@ -147,6 +147,7 @@ platform = ${common.platform}
 framework = ${common.framework}
 monitor_speed = ${common.monitor_speed}
 build_flags = ${common.build_flags}
+    -DEMC_MIN_FREE_MEMORY=8192
 board_build.f_cpu = ${common.cpu_speed}
 ;src_filter = ${common.src_filter}
 lib_deps = ${common.base_lib_deps} ${common.extra_lib_deps}

--- a/lib/node_types/esp/src/main.cpp
+++ b/lib/node_types/esp/src/main.cpp
@@ -138,7 +138,9 @@
     #include <ESP8266mDNS.h>
 
     #ifdef MQTT_USE_TLS
-        const char mqtt_ca_cert_char[] PROGMEM = mqtt_ca_cert; 
+        // Keep CA PEM in normal memory on ESP8266 so BearSSL can parse it reliably.
+        // PROGMEM-backed PEM strings can cause TLS trust-anchor parse failures.
+        const char mqtt_ca_cert_char[] = mqtt_ca_cert;
         BearSSL::X509List *serverTrustedCA = new BearSSL::X509List(mqtt_ca_cert_char);
     #endif
 #endif
@@ -759,7 +761,7 @@ void init_mqtt() {
         mqtt_connected = false;
         ulog(F("MQTT: disconnected. Reason: %u"), static_cast<uint8_t>(reason));
     });
-    
+
     mqttClient.onMessage(onMqttMessage);
     
     // Set client ID
@@ -788,14 +790,22 @@ void init_mqtt() {
     #endif
 
     #ifdef mqtt_server
-        // if defined, just set address
-        mqttClient.setServer(mqtt_server, mqtt_port);
-        ulog(F("Setting mqtt server to: %s:%d"),  mqtt_server, mqtt_port);
+        // If mqtt_server is an IP literal, use the IPAddress overload.
+        // This avoids hostname-verification edge cases on some ESP TLS stacks.
+        IPAddress mqtt_ip_obj;
+        if (mqtt_ip_obj.fromString(mqtt_server)) {
+            mqttClient.setServer(mqtt_ip_obj, mqtt_port);
+            ulog(F("Setting mqtt server to IP: %s:%d"), mqtt_server, mqtt_port);
+        } else {
+            mqttClient.setServer(mqtt_server, mqtt_port);
+            ulog(F("Setting mqtt server to host: %s:%d"), mqtt_server, mqtt_port);
+        }
     #else
         // if not defined, take gateway address
-        mqtt_server_buffer.from(WiFi.gatewayIP().toString().c_str());
-        mqttClient.setServer(mqtt_server_buffer.as_cstr(), mqtt_port);
-        ulog(F("Setting mqtt server ip to: %s:%d"),  mqtt_server_buffer.as_cstr(), mqtt_port);
+        IPAddress gateway_ip = WiFi.gatewayIP();
+        mqtt_server_buffer.from(gateway_ip.toString().c_str());
+        mqttClient.setServer(gateway_ip, mqtt_port);
+        ulog(F("Setting mqtt server IP to: %s:%d"), mqtt_server_buffer.as_cstr(), mqtt_port);
     #endif
 }
 

--- a/tests/test_mqtt_tls_smoke.py
+++ b/tests/test_mqtt_tls_smoke.py
@@ -1,0 +1,148 @@
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import paho.mqtt.client as mqtt
+import pytest
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+@pytest.mark.skipif(
+    shutil.which("openssl") is None or shutil.which("mosquitto") is None,
+    reason="openssl and mosquitto are required for TLS smoke test",
+)
+def test_local_mqtt_tls_smoke(tmp_path: Path) -> None:
+    cert_dir = tmp_path / "certs"
+    cert_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create CA certificate.
+    _run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-sha256",
+            "-days",
+            "1",
+            "-keyout",
+            "ca.key",
+            "-out",
+            "ca.crt",
+            "-subj",
+            "/CN=IoTempowerTestCA",
+        ],
+        cert_dir,
+    )
+
+    # Create server key/csr and sign with CA.
+    _run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            "server.key",
+            "-out",
+            "server.csr",
+            "-subj",
+            "/CN=127.0.0.1",
+        ],
+        cert_dir,
+    )
+    san_file = cert_dir / "server.ext"
+    san_file.write_text("subjectAltName = IP:127.0.0.1,DNS:localhost\n", encoding="utf-8")
+    _run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            "server.csr",
+            "-CA",
+            "ca.crt",
+            "-CAkey",
+            "ca.key",
+            "-CAcreateserial",
+            "-out",
+            "server.crt",
+            "-days",
+            "1",
+            "-sha256",
+            "-extfile",
+            "server.ext",
+        ],
+        cert_dir,
+    )
+
+    port = _find_free_port()
+    conf_file = tmp_path / "mosquitto_tls.conf"
+    conf_file.write_text(
+        "\n".join(
+            [
+                f"listener {port}",
+                "allow_anonymous true",
+                f"cafile {cert_dir / 'ca.crt'}",
+                f"certfile {cert_dir / 'server.crt'}",
+                f"keyfile {cert_dir / 'server.key'}",
+                "require_certificate false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    broker = subprocess.Popen(
+        ["mosquitto", "-c", str(conf_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        time.sleep(0.5)
+        if broker.poll() is not None:
+            stdout, stderr = broker.communicate(timeout=2)
+            pytest.fail(f"mosquitto failed to start.\nstdout:\n{stdout}\nstderr:\n{stderr}")
+
+        received: list[str] = []
+        topic = "iotempower/test/tls"
+        payload = "tls-ok"
+
+        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+        client.tls_set(ca_certs=str(cert_dir / "ca.crt"))
+        client.on_message = lambda _c, _u, msg: received.append(msg.payload.decode("utf-8"))
+        client.connect("127.0.0.1", port, 10)
+        client.loop_start()
+        client.subscribe(topic, qos=0)
+        client.publish(topic, payload=payload, qos=0, retain=False)
+
+        deadline = time.time() + 5
+        while payload not in received and time.time() < deadline:
+            time.sleep(0.05)
+
+        client.loop_stop()
+        client.disconnect()
+
+        assert payload in received, "Did not receive MQTT message over TLS"
+    finally:
+        broker.terminate()
+        try:
+            broker.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            broker.kill()

--- a/tests/test_mqtt_tls_wire_demo.py
+++ b/tests/test_mqtt_tls_wire_demo.py
@@ -1,0 +1,266 @@
+import shutil
+import socket
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import paho.mqtt.client as mqtt
+import pytest
+
+
+DEMO_PAYLOAD = "IOTEMPOWER_TLS_DEMO_MESSAGE"
+DEMO_TOPIC = "iotempower/demo/wire"
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+class SniffingProxy:
+    """Tiny TCP proxy that forwards traffic and stores raw client->server bytes."""
+
+    def __init__(self, listen_port: int, target_port: int):
+        self.listen_port = listen_port
+        self.target_port = target_port
+        self.client_to_server = bytearray()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+        # Give the listener a moment to bind before clients connect.
+        time.sleep(0.1)
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=1)
+
+    def _serve(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server.bind(("127.0.0.1", self.listen_port))
+            server.listen(1)
+            server.settimeout(0.2)
+            while not self._stop.is_set():
+                try:
+                    client_sock, _ = server.accept()
+                except socket.timeout:
+                    continue
+                with client_sock:
+                    with socket.create_connection(("127.0.0.1", self.target_port), timeout=5) as upstream:
+                        client_sock.settimeout(0.2)
+                        upstream.settimeout(0.2)
+                        while not self._stop.is_set():
+                            moved = False
+                            try:
+                                data = client_sock.recv(4096)
+                                if not data:
+                                    break
+                                self.client_to_server.extend(data)
+                                upstream.sendall(data)
+                                moved = True
+                            except socket.timeout:
+                                pass
+                            try:
+                                resp = upstream.recv(4096)
+                                if not resp:
+                                    break
+                                client_sock.sendall(resp)
+                                moved = True
+                            except socket.timeout:
+                                pass
+                            if not moved:
+                                time.sleep(0.01)
+                break  # One connection is enough for this demo.
+
+
+def _mk_client(use_tls: bool, ca_file: Path | None = None) -> mqtt.Client:
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    if use_tls:
+        assert ca_file is not None
+        client.tls_set(ca_certs=str(ca_file))
+    return client
+
+
+def _ascii_preview(data: bytes, max_len: int = 120) -> str:
+    cleaned = []
+    for b in data[:max_len]:
+        if 32 <= b <= 126:
+            cleaned.append(chr(b))
+        else:
+            cleaned.append(".")
+    return "".join(cleaned)
+
+
+@pytest.mark.skipif(
+    shutil.which("openssl") is None or shutil.which("mosquitto") is None,
+    reason="openssl and mosquitto are required for TLS wire demo",
+)
+def test_tls_hides_payload_on_wire_demo(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cert_dir = tmp_path / "certs"
+    cert_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build CA + server cert with SAN so modern TLS validation succeeds.
+    _run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-sha256",
+            "-days",
+            "1",
+            "-keyout",
+            "ca.key",
+            "-out",
+            "ca.crt",
+            "-subj",
+            "/CN=IoTempowerWireDemoCA",
+        ],
+        cert_dir,
+    )
+    _run(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            "server.key",
+            "-out",
+            "server.csr",
+            "-subj",
+            "/CN=127.0.0.1",
+        ],
+        cert_dir,
+    )
+    (cert_dir / "server.ext").write_text("subjectAltName = IP:127.0.0.1,DNS:localhost\n", encoding="utf-8")
+    _run(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            "server.csr",
+            "-CA",
+            "ca.crt",
+            "-CAkey",
+            "ca.key",
+            "-CAcreateserial",
+            "-out",
+            "server.crt",
+            "-days",
+            "1",
+            "-sha256",
+            "-extfile",
+            "server.ext",
+        ],
+        cert_dir,
+    )
+
+    plain_port = _find_free_port()
+    tls_port = _find_free_port()
+    plain_proxy_port = _find_free_port()
+    tls_proxy_port = _find_free_port()
+
+    conf_file = tmp_path / "mosquitto_demo.conf"
+    conf_file.write_text(
+        "\n".join(
+            [
+                f"listener {plain_port}",
+                "allow_anonymous true",
+                f"listener {tls_port}",
+                "allow_anonymous true",
+                f"cafile {cert_dir / 'ca.crt'}",
+                f"certfile {cert_dir / 'server.crt'}",
+                f"keyfile {cert_dir / 'server.key'}",
+                "require_certificate false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    broker = subprocess.Popen(
+        ["mosquitto", "-c", str(conf_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    plain_proxy = SniffingProxy(plain_proxy_port, plain_port)
+    tls_proxy = SniffingProxy(tls_proxy_port, tls_port)
+    plain_proxy.start()
+    tls_proxy.start()
+
+    try:
+        time.sleep(0.5)
+        if broker.poll() is not None:
+            stdout, stderr = broker.communicate(timeout=2)
+            pytest.fail(f"mosquitto failed to start.\nstdout:\n{stdout}\nstderr:\n{stderr}")
+
+        # Plain MQTT publish through sniffing proxy.
+        plain_client = _mk_client(use_tls=False)
+        plain_client.connect("127.0.0.1", plain_proxy_port, 10)
+        plain_client.loop_start()
+        plain_client.publish(DEMO_TOPIC, payload=DEMO_PAYLOAD, qos=0, retain=False)
+        time.sleep(0.3)
+        plain_client.loop_stop()
+        plain_client.disconnect()
+
+        # TLS MQTT publish through sniffing proxy.
+        tls_client = _mk_client(use_tls=True, ca_file=cert_dir / "ca.crt")
+        tls_client.connect("127.0.0.1", tls_proxy_port, 10)
+        tls_client.loop_start()
+        tls_client.publish(DEMO_TOPIC, payload=DEMO_PAYLOAD, qos=0, retain=False)
+        time.sleep(0.5)
+        tls_client.loop_stop()
+        tls_client.disconnect()
+
+        plain_bytes = bytes(plain_proxy.client_to_server)
+        tls_bytes = bytes(tls_proxy.client_to_server)
+        marker = DEMO_PAYLOAD.encode("utf-8")
+
+        plain_has_marker = marker in plain_bytes
+        tls_has_marker = marker in tls_bytes
+
+        with capsys.disabled():
+            print("\n=== MQTT Wire Demo ===")
+            print(f"Payload marker: {DEMO_PAYLOAD}")
+            print("")
+            print("[Plain MQTT]")
+            print(f"- Captured bytes: {len(plain_bytes)}")
+            print(f"- Payload visible on wire: {plain_has_marker}")
+            print(f"- ASCII preview: {_ascii_preview(plain_bytes)}")
+            print("")
+            print("[TLS MQTT]")
+            print(f"- Captured bytes: {len(tls_bytes)}")
+            print(f"- Payload visible on wire: {tls_has_marker}")
+            print(f"- ASCII preview: {_ascii_preview(tls_bytes)}")
+            print("")
+            if plain_has_marker and not tls_has_marker:
+                print("Result: PASS - plain MQTT exposes payload, TLS hides it.")
+            else:
+                print("Result: FAIL - expected payload visibility difference not observed.")
+
+        assert plain_has_marker, "Expected plaintext MQTT to expose payload bytes on wire"
+        assert not tls_has_marker, "Expected TLS MQTT to hide payload bytes on wire"
+    finally:
+        plain_proxy.stop()
+        tls_proxy.stop()
+        broker.terminate()
+        try:
+            broker.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            broker.kill()


### PR DESCRIPTION
## Summary
Improves MQTT TLS behavior for ESP usage and adds quick regression checks.

## Changes
- `bin/mqtt_generate_certificates`
  - add SAN + key usage extensions
  - switch cert generation to RSA-2048 for broader embedded compatibility
- `lib/node_types/esp/src/main.cpp`
  - avoid PROGMEM CA parsing issue on ESP8266 TLS
  - use IP-aware `setServer(...)` path when mqtt host is an IP
- `lib/node_types/esp/platformio.ini`
  - set `EMC_MIN_FREE_MEMORY=8192` for `wemos_d1_mini`
- tests
  - `tests/test_mqtt_tls_smoke.py`
  - `tests/test_mqtt_tls_wire_demo.py`

## Notes / Please review
- `⚠️ maybe-check`: RSA switch (compatibility-driven; worth confirming policy preference vs EC).
- `⚠️ maybe-check`: IPAddress `setServer(...)` branch in ESP code (works in field, but should be reviewed for TLS hostname-verification semantics).
- `⚠️ maybe-check`: lowered `EMC_MIN_FREE_MEMORY` is a practical Wemos fix; please validate acceptable safety margin.
