### PR TITLE
Add functionality to set the TLS buffer size

### DIFF
--- a/lib/node_types/esp/platformio.ini
+++ b/lib/node_types/esp/platformio.ini
@@ -43,7 +43,8 @@ lib_ldf_mode = chain
 cpu_speed = 160000000L
 
 base_lib_deps =
-  bertmelis/espMqttClient@^1.7.2
+  ;bertmelis/espMqttClient@^1.7.2 -- Using a forked lib with added functionality for setting TLS Buffer sizes
+  https://github.com/toomistm/espMqttClient
   https://github.com/iotempire/TrueRMS
 extra_lib_deps = 
 extra_lib_deps_esp32 =

--- a/lib/node_types/esp/platformio.ini
+++ b/lib/node_types/esp/platformio.ini
@@ -43,8 +43,7 @@ lib_ldf_mode = chain
 cpu_speed = 160000000L
 
 base_lib_deps =
-  ;bertmelis/espMqttClient@^1.7.2 -- Using a forked lib with added functionality for setting TLS Buffer sizes
-  https://github.com/toomistm/espMqttClient
+  https://github.com/bertmelis/espMqttClient
   https://github.com/iotempire/TrueRMS
 extra_lib_deps = 
 extra_lib_deps_esp32 =

--- a/lib/node_types/esp/src/main.cpp
+++ b/lib/node_types/esp/src/main.cpp
@@ -782,6 +782,9 @@ void init_mqtt() {
         #else
             // ESP8266 - use trust anchors
             mqttClient.setTrustAnchors(serverTrustedCA);
+            // Set the buffer size for incoming and outgoing traffic
+            mqttClient.setBufferSizes(1024, 1024); 
+            ulog(F("TLS buffers shrunk to 1024 RX / 1024 TX."));
         #endif
     #else
         #define mqtt_port 1883


### PR DESCRIPTION
Added option to set the buffer size for TLS sessions. The default is 16kb, which is too much for the small esp8266 devices. Part of the change included modifying https://github.com/bertmelis/espMqttClient so I forked it. I currently changed the dependency to the forked version only for the wemos_d1_mini setup.