### PR TITLE
[macOS] Fetch correct version of latest Node.js instead of hard-coded maximum during install + bugfixes

### DIFF
--- a/bin/iot_install
+++ b/bin/iot_install
@@ -24,7 +24,7 @@ elif command -v apt-get &> /dev/null; then
 elif command -v brew &> /dev/null; then
   # Additional check for macOS using uname
   if [[ "$(uname)" == "Darwin" ]]; then
-    platform "macos" 
+    platform="macos"
   else
     echo "brew found, but not running on macOS. Please check your configuration."
   fi
@@ -467,11 +467,17 @@ if [[ "$install_system" == 1 ]]; then
   }
 
   if ! check_node; then
-      echo "Trying to install the latest compatible Node.js ($max_version) version."
-      nvm install "$max_version"
-      if ! check_node; then
-          echo "Failed to install a compatible Node.js version."
-          exit 1
+      # Select the latest 'latest' version but make sure it's in range
+      latest_ver=$(nvm ls-remote | grep -i "latest" | tail -1 | grep -Eo '([0-9]+\.?){3,}')
+      latest_ver_maj=$(cut -d '.' -f1 <<< "$latest_ver")
+
+      if [ "$min_version" -le "$latest_ver_maj" ] && [ "$latest_ver_maj" -le "$max_version" ]; then
+        echo "Trying to install the latest compatible Node.js ($latest_ver) version."
+        nvm install "$latest_ver"
+        if ! check_node; then
+            echo "Failed to install a compatible Node.js version."
+            exit 1
+        fi
       fi
   fi
   

--- a/bin/iot_install
+++ b/bin/iot_install
@@ -471,13 +471,16 @@ if [[ "$install_system" == 1 ]]; then
       latest_ver=$(nvm ls-remote | grep -i "latest" | tail -1 | grep -Eo '([0-9]+\.?){3,}')
       latest_ver_maj=$(cut -d '.' -f1 <<< "$latest_ver")
 
+      install_ver=$min_version
       if [ "$min_version" -le "$latest_ver_maj" ] && [ "$latest_ver_maj" -le "$max_version" ]; then
-        echo "Trying to install the latest compatible Node.js ($latest_ver) version."
-        nvm install "$latest_ver"
-        if ! check_node; then
-            echo "Failed to install a compatible Node.js version."
-            exit 1
-        fi
+        install_ver=$latest_ver_maj
+      fi
+
+      echo "Trying to install the latest compatible Node.js ($install_ver) version."
+      nvm install "$latest_ver"
+      if ! check_node; then
+          echo "Failed to install a compatible Node.js version."
+          exit 1
       fi
   fi
   

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,6 +14,10 @@ SPHINXBUILD   = python3 $(shell which sphinx-build)
 BUILDDIR      = "$(IOTEMPOWER_LOCAL)/doc"
 SOURCEDIR     = "$(BUILDDIR)/_src"
 
+ifeq ($(SPHINX_BUILD),)
+$(error sphinx-build not found)
+endif
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
## Problem

During installation, if no suitable Node.js versions are detected by nvm, it defaults to installing and activating the `max_version` version, which is hard-coded to `30`, which does not exist (yet).

## Solution

Run `nvm ls-remote`, filter by versions tagged `latest` and select the last item. Then check to see if it falls within the `min_version` and `max_version` range, fallback to `min_version` if not.

## Additional bugs

I realize that including multiple different bug fixes in one PR is frowned upon, but I believe that the following fixes are tiny enough to warrant an exception:

1. Fixed a typo in the environment check logic, now `platform="macos"` is set correctly.
2. Added an existence check for the sphinx library in the Makefile for `doc`. This way the script exits early instead of dumping errors, as it did on my system after failing to install python requirements correctly during previous installation steps.