### PR TITLE
[macOS] Fix bug in node version selection logic; ensure doc file exists before linking to avoid ugly error

### DIFF
--- a/bin/iot_doc
+++ b/bin/iot_doc
@@ -53,9 +53,13 @@ create_doc() {
     # make html SPHINXOPTS=-v
     iot_grun make html
     # TODO: do eventually a matching specific version here
-    ln -s -f "$IOTEMPOWER_LOCAL/doc/html/doc/index.html" \
-        "$IOTEMPOWER_LOCAL/doc/html/index.html"
-    echo "Documentation creation finished."
+    local_doc="$IOTEMPOWER_LOCAL/doc/html/doc/index.html"
+    if [ -e "$local_doc" ]; then
+        ln -s -f "$local_doc" "$IOTEMPOWER_LOCAL/doc/html/index.html"
+        echo "Documentation creation finished."
+    else
+        echo "Documentation creation unsuccessful."
+    fi
 }
 
 

--- a/bin/iot_install
+++ b/bin/iot_install
@@ -24,7 +24,7 @@ elif command -v apt-get &> /dev/null; then
 elif command -v brew &> /dev/null; then
   # Additional check for macOS using uname
   if [[ "$(uname)" == "Darwin" ]]; then
-    platform "macos" 
+    platform="macos"
   else
     echo "brew found, but not running on macOS. Please check your configuration."
   fi
@@ -467,11 +467,17 @@ if [[ "$install_system" == 1 ]]; then
   }
 
   if ! check_node; then
-      echo "Trying to install the latest compatible Node.js ($max_version) version."
-      nvm install "$max_version"
-      if ! check_node; then
-          echo "Failed to install a compatible Node.js version."
-          exit 1
+      # Select the latest 'latest' version but make sure it's in range
+      latest_ver=$(nvm ls-remote | grep -i "latest" | tail -1 | grep -Eo '([0-9]+\.?){3,}')
+      latest_ver_maj=$(cut -d '.' -f1 <<< "$latest_ver")
+
+      if [ "$min_version" -le "$latest_ver_maj" ] && [ "$latest_ver_maj" -le "$max_version" ]; then
+        echo "Trying to install the latest compatible Node.js ($latest_ver) version."
+        nvm install "$latest_ver"
+        if ! check_node; then
+            echo "Failed to install a compatible Node.js version."
+            exit 1
+        fi
       fi
   fi
   

--- a/bin/iot_install
+++ b/bin/iot_install
@@ -471,13 +471,16 @@ if [[ "$install_system" == 1 ]]; then
       latest_ver=$(nvm ls-remote | grep -i "latest" | tail -1 | grep -Eo '([0-9]+\.?){3,}')
       latest_ver_maj=$(cut -d '.' -f1 <<< "$latest_ver")
 
+      install_ver=$min_version
       if [ "$min_version" -le "$latest_ver_maj" ] && [ "$latest_ver_maj" -le "$max_version" ]; then
-        echo "Trying to install the latest compatible Node.js ($latest_ver) version."
-        nvm install "$latest_ver"
-        if ! check_node; then
-            echo "Failed to install a compatible Node.js version."
-            exit 1
-        fi
+        install_ver=$latest_ver_maj
+      fi
+
+      echo "Trying to install the latest compatible Node.js ($install_ver) version."
+      nvm install "$latest_ver"
+      if ! check_node; then
+          echo "Failed to install a compatible Node.js version."
+          exit 1
       fi
   fi
   

--- a/bin/iot_install
+++ b/bin/iot_install
@@ -473,11 +473,11 @@ if [[ "$install_system" == 1 ]]; then
 
       install_ver=$min_version
       if [ "$min_version" -le "$latest_ver_maj" ] && [ "$latest_ver_maj" -le "$max_version" ]; then
-        install_ver=$latest_ver_maj
+        install_ver=$latest_ver
       fi
 
       echo "Trying to install the latest compatible Node.js ($install_ver) version."
-      nvm install "$latest_ver"
+      nvm install "$install_ver"
       if ! check_node; then
           echo "Failed to install a compatible Node.js version."
           exit 1

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,6 +14,10 @@ SPHINXBUILD   = python3 $(shell which sphinx-build)
 BUILDDIR      = "$(IOTEMPOWER_LOCAL)/doc"
 SOURCEDIR     = "$(BUILDDIR)/_src"
 
+ifeq ($(SPHINX_BUILD),)
+$(error sphinx-build not found)
+endif
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
Accidentally left a bug in the node version selection logic: forward the actual `install_ver` to `nvm`.

Additionally, don't link the documentation file if it doesn't exist due to failed setup. 