### PR TITLE
Parse system and node config files as inert data

### DIFF
--- a/bin/config_parser
+++ b/bin/config_parser
@@ -1,0 +1,231 @@
+#@IgnoreInspection BashAddShebang
+# Parse IoTempower config files as inert key/value data.
+#
+# Supported syntax:
+#   KEY=value
+#   KEY="value with spaces"
+#   KEY='literal value'
+#   export KEY=value
+# Empty lines and lines beginning with # are ignored. Inline comments are
+# accepted after whitespace following a value.
+
+_iotempower_config_error() {
+    local file="$1"
+    local line_no="$2"
+    local message="$3"
+    echo "$file:$line_no: $message" 1>&2
+}
+
+_iotempower_config_key_allowed() {
+    local mode="$1"
+    local key="$2"
+
+    case "$mode" in
+        system)
+            case "$key" in
+                IOTEMPOWER_*|system_name)
+                    return 0
+                    ;;
+            esac
+            return 1
+            ;;
+        node)
+            case "$key" in
+                board|topic|mqtt_server|mqtt_user|mqtt_password|IOTEMPOWER_*)
+                    return 0
+                    ;;
+            esac
+            return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+_iotempower_config_mode_allowed() {
+    case "$1" in
+        system|node)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+_iotempower_config_ltrim() {
+    local text="$1"
+    text="${text#"${text%%[!$' \t\r\n']*}"}"
+    printf '%s' "$text"
+}
+
+_iotempower_config_parse_value() {
+    local raw="$1"
+    local file="$2"
+    local line_no="$3"
+    local value=""
+    local tail=""
+    local i=0
+    local len=0
+    local ch=""
+    local next=""
+
+    raw="$(_iotempower_config_ltrim "$raw")"
+    if [[ -z "$raw" || "${raw:0:1}" == "#" ]]; then
+        __IOTEMPOWER_CONFIG_VALUE=""
+        return 0
+    fi
+
+    case "${raw:0:1}" in
+        '"')
+            len=${#raw}
+            i=1
+            while (( i < len )); do
+                ch="${raw:i:1}"
+                if [[ "$ch" == '"' ]]; then
+                    tail="${raw:i+1}"
+                    tail="$(_iotempower_config_ltrim "$tail")"
+                    if [[ -n "$tail" && "${tail:0:1}" != "#" ]]; then
+                        _iotempower_config_error "$file" "$line_no" "unexpected text after quoted value"
+                        return 1
+                    fi
+                    __IOTEMPOWER_CONFIG_VALUE="$value"
+                    return 0
+                fi
+                if [[ "$ch" == "\\" ]]; then
+                    (( i++ ))
+                    if (( i >= len )); then
+                        _iotempower_config_error "$file" "$line_no" "unterminated escape in quoted value"
+                        return 1
+                    fi
+                    next="${raw:i:1}"
+                    case "$next" in
+                        '"'|'\'|'$'|'`')
+                            value+="$next"
+                            ;;
+                        *)
+                            value+="\\$next"
+                            ;;
+                    esac
+                else
+                    value+="$ch"
+                fi
+                (( i++ ))
+            done
+            _iotempower_config_error "$file" "$line_no" "unterminated quoted value"
+            return 1
+            ;;
+        "'")
+            len=${#raw}
+            i=1
+            while (( i < len )); do
+                ch="${raw:i:1}"
+                if [[ "$ch" == "'" ]]; then
+                    tail="${raw:i+1}"
+                    tail="$(_iotempower_config_ltrim "$tail")"
+                    if [[ -n "$tail" && "${tail:0:1}" != "#" ]]; then
+                        _iotempower_config_error "$file" "$line_no" "unexpected text after quoted value"
+                        return 1
+                    fi
+                    __IOTEMPOWER_CONFIG_VALUE="$value"
+                    return 0
+                fi
+                value+="$ch"
+                (( i++ ))
+            done
+            _iotempower_config_error "$file" "$line_no" "unterminated quoted value"
+            return 1
+            ;;
+        *)
+            if [[ "$raw" =~ ^([^[:space:]]*)([[:space:]]+.*)?$ ]]; then
+                value="${BASH_REMATCH[1]}"
+                tail="${BASH_REMATCH[2]}"
+                tail="$(_iotempower_config_ltrim "$tail")"
+                if [[ -n "$tail" && "${tail:0:1}" != "#" ]]; then
+                    _iotempower_config_error "$file" "$line_no" "unquoted values may not contain whitespace"
+                    return 1
+                fi
+                __IOTEMPOWER_CONFIG_VALUE="$value"
+                return 0
+            fi
+            _iotempower_config_error "$file" "$line_no" "invalid value"
+            return 1
+            ;;
+    esac
+}
+
+iotempower_read_config() {
+    local mode="$1"
+    local file="$2"
+    local line=""
+    local rest=""
+    local key=""
+    local value=""
+    local line_no=0
+    local export_assignment=""
+    local -a keys=()
+    local -a values=()
+    local -a exports=()
+    local i=0
+
+    if [[ -z "$mode" || -z "$file" ]]; then
+        echo "iotempower_read_config: usage: iotempower_read_config <system|node> <file>" 1>&2
+        return 1
+    fi
+
+    if ! _iotempower_config_mode_allowed "$mode"; then
+        echo "iotempower_read_config: unsupported config mode '$mode'" 1>&2
+        return 1
+    fi
+
+    if [[ ! -r "$file" ]]; then
+        echo "Can't read $file. Aborting." 1>&2
+        return 1
+    fi
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line_no=$(( line_no + 1 ))
+        line="${line%$'\r'}"
+        rest="$(_iotempower_config_ltrim "$line")"
+        if [[ -z "$rest" || "${rest:0:1}" == "#" ]]; then
+            continue
+        fi
+
+        export_assignment=""
+        if [[ "$rest" =~ ^export[[:space:]]+(.+)$ ]]; then
+            export_assignment=yes
+            rest="${BASH_REMATCH[1]}"
+        fi
+
+        if [[ ! "$rest" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+            _iotempower_config_error "$file" "$line_no" "expected key=value assignment"
+            return 1
+        fi
+
+        key="${BASH_REMATCH[1]}"
+        rest="${BASH_REMATCH[2]}"
+
+        if ! _iotempower_config_key_allowed "$mode" "$key"; then
+            _iotempower_config_error "$file" "$line_no" "unsupported key '$key' for $mode config"
+            return 1
+        fi
+
+        if ! _iotempower_config_parse_value "$rest" "$file" "$line_no"; then
+            return 1
+        fi
+        value="$__IOTEMPOWER_CONFIG_VALUE"
+
+        keys+=("$key")
+        values+=("$value")
+        exports+=("$export_assignment")
+    done < "$file"
+
+    for (( i = 0; i < ${#keys[@]}; i++ )); do
+        key="${keys[$i]}"
+        printf -v "$key" '%s' "${values[$i]}"
+        if [[ "${exports[$i]}" ]]; then
+            export "$key"
+        fi
+    done
+}

--- a/bin/iot_env
+++ b/bin/iot_env
@@ -27,5 +27,7 @@ else
   source "$IOTEMPOWER_ROOT/bin/read_node_config"
 fi
 
-# output and quote result
-env|grep -E "^IOTEMPOWER"|sed 's/^\([^=]*\)=\(.*\)$/export\ \1=\"\2\"/g'
+# output shell-safe exports for callers that source <(iot_env ...)
+while IFS= read -r key; do
+  printf 'export %s=%q\n' "$key" "${!key}"
+done < <(compgen -A variable IOTEMPOWER | sort)

--- a/bin/mqtt_action
+++ b/bin/mqtt_action
@@ -30,6 +30,10 @@ fi
 
 [ "$IOTEMPOWER_ACTIVE" = "yes" ] || { echo "IoTempower not active, aborting." 1>&2;exit 1; }
 source <( iot_env ignore_system )
+source "$IOTEMPOWER_ROOT/bin/config_parser" || {
+    echo "Can't read $IOTEMPOWER_ROOT/bin/config_parser. Aborting." 1>&2
+    exit 1
+}
 
 arg_topic="$1"
 trigger_type="$2"
@@ -40,7 +44,9 @@ shift 3
 if [[ -e "node.conf" || -e "../node.conf" ]]; then  # started from node-directory
     source "$IOTEMPOWER_ROOT/bin/read_node_config"
 else # Check if in system directory and read
-    source "system.conf" &> /dev/null
+    if [[ -e "system.conf" ]]; then
+        iotempower_read_config system "system.conf" || { echo "Can't read system.conf. Aborting." 1>&2;exit 1; }
+    fi
 fi
 
 if [[ "$arg_topic" = "/"* ]]; then

--- a/bin/read_node_config
+++ b/bin/read_node_config
@@ -16,13 +16,16 @@ __IOTEMPOWER_NONODE=""
     fi
 }
 
-source "$IOTEMPOWER_ROOT/bin/read_system_config"
+source "$IOTEMPOWER_ROOT/bin/read_system_config" || {
+    echo "Can't read $IOTEMPOWER_ROOT/bin/read_system_config. Aborting." 1>&2
+    exit 1
+}
 # topic of current node now in $topic
 
 board="wemos d1 mini" # TODO: does this default need to be updated?
 
 if [[ ! "$__IOTEMPOWER_NONODE" ]]; then
-    source "node.conf" || { echo "Can't read node.conf. Aborting." 1>&2;exit 1; }
+    iotempower_read_config node "node.conf" || { echo "Can't read node.conf. Aborting." 1>&2;exit 1; }
 fi
 
 # must be after sourcing node.conf

--- a/bin/read_system_config
+++ b/bin/read_system_config
@@ -4,6 +4,11 @@
 # if __IOTEMPOWER_NOERROR is set, it will not exit
 # when files are not found.
 
+source "$IOTEMPOWER_ROOT/bin/config_parser" || {
+    echo "Can't read $IOTEMPOWER_ROOT/bin/config_parser. Aborting." 1>&2
+    exit 1
+}
+
 # search system.conf in parent directories and build a respective path to self
 # this search goes the following number of levels up max
 parent_levels=5
@@ -31,18 +36,26 @@ source "$IOTEMPOWER_ROOT/bin/read_boot_config"
 # should have been read for iot-environment
 # just read it again here
 if [[ -e "$IOTEMPOWER_ROOT/etc/iotempower.conf" ]]; then
-    source "$IOTEMPOWER_ROOT/etc/iotempower.conf"
+    iotempower_read_config system "$IOTEMPOWER_ROOT/etc/iotempower.conf" || {
+        echo "Can't read $IOTEMPOWER_ROOT/etc/iotempower.conf. Aborting." 1>&2
+        exit 1
+    }
 fi
 
 # last, read a locally available system.conf, can overwrite everything
 _IOTEMPOWER_TMP="$IOTEMPOWER_AP_NAME"
 IOTEMPOWER_AP_NAME="__IOTEMPOWER_TEST__"
-source "system.conf" &> /dev/null || { 
+if [[ -e "system.conf" ]]; then
+    iotempower_read_config system "system.conf" || {
+        echo "Can't read system.conf. Aborting." 1>&2
+        exit 1
+    }
+else
     if [[ ! "$__IOTEMPOWER_NOERROR" ]]; then
         echo "Can't read system.conf. Aborting." 1>&2
         exit 1 
     fi
-}
+fi
 IOTEMPOWER_SYSTEM_CONFIG="$(pwd)/system.conf"
 
 if [[ ! -e "$IOTEMPOWER_MQTT_CERT_FOLDER" ]]; then

--- a/lib/shell_starter/config.bash
+++ b/lib/shell_starter/config.bash
@@ -53,11 +53,12 @@ IOTEMPOWER_WEBREPL_PW="iotempower"
 
 # first read local boot configuration
 source $IOTEMPOWER_ROOT/bin/read_boot_config
+source "$IOTEMPOWER_ROOT/bin/config_parser" || { return 1 2>/dev/null || exit 1; }
 
 
 # second read config in etc, can overwrite boot config
 if [ -e "$IOTEMPOWER_ROOT/etc/iotempower.conf" ]; then
-    source "$IOTEMPOWER_ROOT/etc/iotempower.conf"
+    iotempower_read_config system "$IOTEMPOWER_ROOT/etc/iotempower.conf" || { return 1 2>/dev/null || exit 1; }
 fi
 
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,150 @@
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PARSER = ROOT / "bin" / "config_parser"
+
+
+def run_bash(script):
+    return subprocess.run(
+        ["bash"],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_system_config_is_inert_and_preserves_shell_syntax(tmp_path):
+    marker = tmp_path / "executed"
+    config = tmp_path / "system.conf"
+    config.write_text(
+        textwrap.dedent(
+            f"""\
+            # comments and blank lines are ignored
+
+            IOTEMPOWER_AP_NAME="name with spaces" # inline comment
+            IOTEMPOWER_MQTT_HOST="$(touch {marker})"
+            IOTEMPOWER_MQTT_PW='`touch {marker}`'
+            export IOTEMPOWER_WEBREPL_PW=$HOME
+            """
+        )
+    )
+
+    result = run_bash(
+        textwrap.dedent(
+            f"""\
+            set -e
+            source "{PARSER}"
+            iotempower_read_config system "{config}"
+            printf '%s\\n' "$IOTEMPOWER_AP_NAME"
+            printf '%s\\n' "$IOTEMPOWER_MQTT_HOST"
+            printf '%s\\n' "$IOTEMPOWER_MQTT_PW"
+            printf '%s\\n' "$IOTEMPOWER_WEBREPL_PW"
+            export -p | grep -q 'IOTEMPOWER_WEBREPL_PW'
+            """
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "name with spaces",
+        f"$(touch {marker})",
+        f"`touch {marker}`",
+        "$HOME",
+    ]
+    assert not marker.exists()
+
+
+def test_node_config_accepts_only_expected_node_keys(tmp_path):
+    config = tmp_path / "node.conf"
+    config.write_text(
+        textwrap.dedent(
+            """\
+            board="wemos d1 mini"
+            topic='room/sensor'
+            mqtt_server=broker
+            mqtt_user=user
+            mqtt_password='pass word'
+            """
+        )
+    )
+
+    result = run_bash(
+        textwrap.dedent(
+            f"""\
+            set -e
+            source "{PARSER}"
+            iotempower_read_config node "{config}"
+            printf '%s\\n' "$board" "$topic" "$mqtt_server" "$mqtt_user" "$mqtt_password"
+            """
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "wemos d1 mini",
+        "room/sensor",
+        "broker",
+        "user",
+        "pass word",
+    ]
+
+
+def test_rejects_custom_key_without_partial_assignment(tmp_path):
+    config = tmp_path / "system.conf"
+    config.write_text(
+        textwrap.dedent(
+            """\
+            IOTEMPOWER_AP_NAME=new-name
+            CUSTOM_KEY=value
+            """
+        )
+    )
+
+    result = run_bash(
+        textwrap.dedent(
+            f"""\
+            source "{PARSER}"
+            IOTEMPOWER_AP_NAME=original
+            iotempower_read_config system "{config}"
+            status=$?
+            printf '%s\\n' "$status" "$IOTEMPOWER_AP_NAME"
+            """
+        )
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["1", "original"]
+    assert "unsupported key 'CUSTOM_KEY' for system config" in result.stderr
+
+
+def test_rejects_ambiguous_whitespace_and_unsupported_mode(tmp_path):
+    config = tmp_path / "system.conf"
+    config.write_text("IOTEMPOWER_AP_NAME=bad value\n")
+
+    whitespace_result = run_bash(
+        textwrap.dedent(
+            f"""\
+            source "{PARSER}"
+            iotempower_read_config system "{config}"
+            """
+        )
+    )
+    assert whitespace_result.returncode == 1
+    assert "unquoted values may not contain whitespace" in whitespace_result.stderr
+
+    empty_config = tmp_path / "empty.conf"
+    empty_config.write_text("")
+    mode_result = run_bash(
+        textwrap.dedent(
+            f"""\
+            source "{PARSER}"
+            iotempower_read_config wifi "{empty_config}"
+            """
+        )
+    )
+    assert mode_result.returncode == 1
+    assert "unsupported config mode 'wifi'" in mode_result.stderr

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -142,9 +142,9 @@ def test_rejects_ambiguous_whitespace_and_unsupported_mode(tmp_path):
         textwrap.dedent(
             f"""\
             source "{PARSER}"
-            iotempower_read_config wifi "{empty_config}"
+            iotempower_read_config custom "{empty_config}"
             """
         )
     )
     assert mode_result.returncode == 1
-    assert "unsupported config mode 'wifi'" in mode_result.stderr
+    assert "unsupported config mode 'custom'" in mode_result.stderr


### PR DESCRIPTION
Adds strict inert parsing for system/node config files, rejects shell execution syntax, and updates core config-loading paths without including Wi-Fi/AP/OpenWRT scope.

