### PR TITLE
Add GMP343 and Soil 7-in-1 serial sensor docs improvements

### DIFF
--- a/doc/node_help/gmp343.rst
+++ b/doc/node_help/gmp343.rst
@@ -44,3 +44,41 @@ Example
 ..  code-block:: cpp
 
     gmp343(co2, D6, D7);
+
+Wiring
+------
+
+- This sensor needs a TTL-RS232 adapter to connect to an ESP8266 or ESP32.
+
+- Power the GMP343 sensor from an external power supply that matches the sensor
+  specification.
+
+- Connect the GMP343 serial ``TX`` line to the RS232 adapter serial ``TX`` line.
+
+- Connect the GMP343 serial ``RX`` line to the RS232 adapter serial ``RX`` line.
+
+- Connect the GMP343 serial ground to the RS232 adapter ground.
+
+- Connect the controller ``rx_pin`` and ``tx_pin`` to the TTL side of the
+  RS232 adapter.
+
+- Depending on the adapter labeling, these TTL serial lines may need either
+  crossed wiring or straight wiring.
+
+- If communication does not work, swap the two TTL serial lines on the
+  adapter ``RXD`` and ``TXD`` pins.
+
+For example:
+
+..  code-block:: cpp
+
+    gmp343(co2, D6, D7);
+
+In this example:
+
+- ``D6`` is used as ``rx_pin`` and ``D7`` is used as ``tx_pin`` on the ESP side.
+
+- These two pins connect to the TTL serial side of the RS232 adapter.
+
+- If the sensor does not respond, try swapping these two serial lines on the
+  adapter ``RXD`` and ``TXD`` pins.

--- a/doc/node_help/soil_7in1.rst
+++ b/doc/node_help/soil_7in1.rst
@@ -79,3 +79,39 @@ Only moisture and temperature:
 
     soil_7in1(soil, D6, D7, 4800, SWSERIAL_8N1, false, 0x01, -1, 400, 3,
         true, true, false, false, false, false, false, false, false);
+
+Wiring
+------
+
+- This sensor needs a TTL-RS485 adapter to connect to an ESP8266 or ESP32.
+
+- Connect the soil sensor RS485 ``A`` line to the adapter ``A`` line.
+
+- Connect the soil sensor RS485 ``B`` line to the adapter ``B`` line.
+
+- Power the soil sensor from an external power supply that matches the sensor
+  specification.
+
+- Connect the controller ``rx_pin`` and ``tx_pin`` to the TTL side of the
+  RS485 adapter.
+
+- Depending on the adapter labeling, these TTL serial lines may need either
+  crossed wiring or straight wiring.
+
+- If communication does not work, swap the two TTL serial lines on the
+  adapter ``RXD`` and ``TXD`` pins.
+
+For example:
+
+..  code-block:: cpp
+
+    soil_7in1(soil, D6, D7);
+
+In this example:
+
+- ``D6`` is used as ``rx_pin`` and ``D7`` is used as ``tx_pin`` on the ESP side.
+
+- These two pins connect to the TTL serial side of the RS485 adapter.
+
+- If the sensor does not respond, try swapping these two serial lines on the
+  adapter ``RXD`` and ``TXD`` pins.


### PR DESCRIPTION
Updates the GMP343 and soil_7in1 sensor documentation with clearer wiring instructions, including adapter usage and serial line notes.